### PR TITLE
Exit on NaN loss

### DIFF
--- a/open_lm/main.py
+++ b/open_lm/main.py
@@ -606,13 +606,16 @@ def main(args):
                 tb_writer=writer,
             )
 
+        except ValueError as e:
+            # in this case stop training, log the error and exit cleanly
             if args.distributed:
                 dist.barrier()
 
-        except ValueError as e:
-            # in this case stop training, log the error and exit cleanly
             logging.exception(e)
             break
+
+        if args.distributed:
+                dist.barrier()
 
         completed_epoch = epoch + 1
         evaluation_loss = -1

--- a/open_lm/main.py
+++ b/open_lm/main.py
@@ -593,8 +593,7 @@ def main(args):
         if args.distributed:
             dist.barrier()
 
-        try:
-            train_one_epoch(
+        success = train_one_epoch(
                 model,
                 data,
                 loss,
@@ -606,16 +605,12 @@ def main(args):
                 tb_writer=writer,
             )
 
-        except ValueError as e:
-            # in this case stop training, log the error and exit cleanly
-            if args.distributed:
-                dist.barrier()
-
-            logging.exception(e)
-            break
-
         if args.distributed:
             dist.barrier()
+
+        if not success:
+            logging.info(f"Training exiting due to NaN value")
+            break
 
         completed_epoch = epoch + 1
         evaluation_loss = -1

--- a/open_lm/main.py
+++ b/open_lm/main.py
@@ -615,7 +615,7 @@ def main(args):
             break
 
         if args.distributed:
-                dist.barrier()
+            dist.barrier()
 
         completed_epoch = epoch + 1
         evaluation_loss = -1

--- a/open_lm/train.py
+++ b/open_lm/train.py
@@ -195,6 +195,14 @@ def train_one_epoch(
             # resetting batch / data time meters per log window
             batch_time_m.reset()
             data_time_m.reset()
+
+            if math.isnan(losses_m.val):
+                # case where loss goes to nan, we see this sometimes with bad nodes.
+                # in this case we would like to free resources and prevent other issues
+                # e.g., saving checkpoints and optmization states that may lead to skipped
+                # training on restarts.
+                raise ValueError("loss gone to NaN")
+
     # end for
 
 

--- a/open_lm/train.py
+++ b/open_lm/train.py
@@ -201,9 +201,10 @@ def train_one_epoch(
                 # in this case we would like to free resources and prevent other issues
                 # e.g., saving checkpoints and optmization states that may lead to skipped
                 # training on restarts.
-                raise ValueError("loss gone to NaN")
+                return False
 
     # end for
+    return True
 
 
 def evaluate(model, data, start_epoch, args, writer):


### PR DESCRIPTION
In cases where loss goes to nan (e.g., bad nodes or bad hparams), we would like to raise an exception, free resources and prevent other issues like saving checkpoints and optimization states that may lead to skipped training on restarts.