### PR TITLE
Add generation scripts

### DIFF
--- a/open_lm/utils/transformers/config.py
+++ b/open_lm/utils/transformers/config.py
@@ -13,6 +13,7 @@ class OpenLMConfig(PretrainedConfig):
         vocab_size: int = 50304,
         post_embed_norm: bool = False,
         weight_tying: bool = False,
+        model_norm: str = "default_layer_norm",
         **kwargs
     ):
         # Used by huggingface transformers
@@ -25,6 +26,7 @@ class OpenLMConfig(PretrainedConfig):
         self.post_embed_norm = post_embed_norm
         self.weight_tying = weight_tying
         self.tie_word_embeddings = weight_tying
+        self.model_norm = model_norm
 
 
 if __name__ == '__main__':

--- a/open_lm/utils/transformers/config.py
+++ b/open_lm/utils/transformers/config.py
@@ -15,7 +15,8 @@ class OpenLMConfig(PretrainedConfig):
         weight_tying: bool = False,
         **kwargs
     ):
-        
+        # Used by huggingface transformers
+        super().__init__(**kwargs)
         self.hidden_dim = hidden_dim
         self.n_layers = n_layers
         self.n_heads = n_heads
@@ -23,8 +24,7 @@ class OpenLMConfig(PretrainedConfig):
         self.vocab_size = vocab_size
         self.post_embed_norm = post_embed_norm
         self.weight_tying = weight_tying
-        super().__init__(**kwargs)
-
+        self.tie_word_embeddings = weight_tying
 
 
 if __name__ == '__main__':

--- a/open_lm/utils/transformers/model.py
+++ b/open_lm/utils/transformers/model.py
@@ -5,6 +5,9 @@ from open_lm.model import Params, Transformer
 import torch
 from typing import Union, Tuple, Optional, List
 
+from open_lm.norms import get_norm_class
+
+
 def create_model(cfg):
 
     model_args = Params(
@@ -15,6 +18,9 @@ def create_model(cfg):
         vocab_size=cfg.vocab_size,
         post_embed_norm=cfg.post_embed_norm,
         weight_tying=cfg.weight_tying,
+        norm_type=get_norm_class(cfg),
+        apply_qk_norm=cfg.qk_norm,
+        rotary_old=cfg.rotary_old
     )
     model = Transformer(model_args)
 

--- a/scripts/generate.py
+++ b/scripts/generate.py
@@ -1,0 +1,65 @@
+import argparse
+import json
+import builtins as __builtin__
+
+import torch
+
+from composer.utils import dist, get_device
+from open_lm.utils.transformers.model import OpenLMforCausalLM
+from open_lm.utils.transformers.config import OpenLMConfig
+from open_lm.utils.llm_foundry_wrapper import SimpleComposerOpenLMCausalLM
+from transformers import GPTNeoXTokenizerFast
+
+
+builtin_print = __builtin__.print
+
+
+@torch.inference_mode()
+def run_model(open_lm: OpenLMforCausalLM, tokenizer, cfg, args):
+    dist.initialize_dist(get_device(None), timeout=600)
+    input = tokenizer(args.input_text)
+    input = {k: torch.tensor(v).unsqueeze(0).cuda() for k, v in input.items()}
+    composer_model = SimpleComposerOpenLMCausalLM(open_lm, tokenizer)
+    output = composer_model.generate(
+        input["input_ids"],
+        pad_token_id=50282,
+        do_sample=args.temperature > 0,
+        temperature=args.temperature,
+        top_p=args.top_p,
+        max_new_tokens=args.max_gen_len,
+    )
+    output = tokenizer.decode(output[0].cpu().numpy())
+    print(output)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--checkpoint")
+    parser.add_argument("--model-config")
+    parser.add_argument("--input-text", required=True)
+    parser.add_argument("--rotary-old", action="store_true")
+    parser.add_argument("--qk-norm", action="store_true")
+    parser.add_argument('--max-gen-len', default=200)
+    parser.add_argument('--temperature', default=0.8)
+    parser.add_argument('--top-p', default=0.95)
+    args = parser.parse_args()
+
+    checkpoint = torch.load(args.checkpoint)
+    with open(args.model_config, "r") as f:
+        model_cfg = json.load(f)
+
+    model_cfg["rotary_old"] = args.rotary_old
+    model_cfg["qk_norm"] = args.qk_norm
+
+    open_lm = OpenLMforCausalLM(OpenLMConfig(**model_cfg))
+    tokenizer = GPTNeoXTokenizerFast.from_pretrained("EleutherAI/gpt-neox-20b")
+
+    state_dict = checkpoint["state_dict"]
+    state_dict = {x.replace("module.", ""): y for x, y in state_dict.items()}
+    open_lm.model.load_state_dict(state_dict)
+    open_lm.eval().cuda()
+    run_model(open_lm, tokenizer, model_cfg, args)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/generate.py
+++ b/scripts/generate.py
@@ -1,3 +1,5 @@
+"""Script to generate text from a trained model using HuggingFace wrappers."""
+
 import argparse
 import json
 import builtins as __builtin__
@@ -39,9 +41,9 @@ def main():
     parser.add_argument("--input-text", required=True)
     parser.add_argument("--rotary-old", action="store_true")
     parser.add_argument("--qk-norm", action="store_true")
-    parser.add_argument('--max-gen-len', default=200)
-    parser.add_argument('--temperature', default=0.8)
-    parser.add_argument('--top-p', default=0.95)
+    parser.add_argument('--max-gen-len', default=200, type=int)
+    parser.add_argument('--temperature', default=0.8, type=float)
+    parser.add_argument('--top-p', default=0.95, type=float)
     args = parser.parse_args()
 
     checkpoint = torch.load(args.checkpoint)

--- a/scripts/generate_without_hf.py
+++ b/scripts/generate_without_hf.py
@@ -1,0 +1,149 @@
+"""Script to generate text from a trained model, without HuggingFace wrappers.
+
+This script is useful for simple generation, and to debug any issues with HuggingFace integration.
+The output of this script should match that of generate.py when `--temperature 0` is passed.
+"""
+
+# Thanks to Gabriel for this code.
+import argparse
+import os
+import glob
+import yaml
+from dataclasses import dataclass
+from typing import List
+from yaml import Loader
+
+import torch
+from transformers import GPTNeoXTokenizerFast
+
+from open_lm.model import Transformer, create_model
+
+
+@dataclass
+class GenerationArgs:
+    max_gen_len: int = 200
+    temperature: float = 0.8
+    top_p: float = 0.95
+
+
+class Generator:
+    def __init__(self, model: Transformer):
+        self.model = model
+        self.tokenizer = GPTNeoXTokenizerFast.from_pretrained("EleutherAI/gpt-neox-20b")
+        self.pad_token_id = 50282
+        self.seq_len = 2048
+
+    @torch.inference_mode()
+    def generate(
+        self,
+        prompts: List[str],
+        gen_args: GenerationArgs = GenerationArgs(),
+    ) -> List[str]:
+        bsz = len(prompts)
+
+        prompt_tokens = [self.tokenizer.encode(x) for x in prompts]
+
+        min_prompt_size = min([len(t) for t in prompt_tokens])
+        max_prompt_size = max([len(t) for t in prompt_tokens])
+
+        total_len = min(self.seq_len, gen_args.max_gen_len + max_prompt_size)
+
+        tokens = torch.full((bsz, total_len), self.pad_token_id).cuda().long()
+        for k, t in enumerate(prompt_tokens):
+            tokens[k, : len(t)] = torch.tensor(t).long()
+        input_text_mask = tokens != self.pad_token_id
+        start_pos = min_prompt_size
+        prev_pos = 0
+        for cur_pos in range(start_pos, total_len):
+            last_logits = self.model(tokens[:, prev_pos:cur_pos].clone())[0][:, -1, :]
+            if gen_args.temperature > 0:
+                probs = torch.softmax(last_logits / gen_args.temperature, dim=-1)
+                next_token = sample_top_p(probs, gen_args.top_p)
+            else:
+                next_token = torch.argmax(last_logits, dim=-1)
+            next_token = next_token.reshape(-1)
+            # only replace token if prompt has already been generated
+            next_token = torch.where(
+                input_text_mask[:, cur_pos], tokens[:, cur_pos], next_token
+            )
+            tokens[:, cur_pos] = next_token
+
+            # TODO: enable caching again for inference
+            # prev_pos = cur_pos
+
+        decoded = []
+        for i, t in enumerate(tokens.tolist()):
+            t = t[: len(prompt_tokens[i]) + gen_args.max_gen_len]
+            decoded_i = self.tokenizer.decode(t)
+
+            decoded = []
+            for t in decoded_i:
+                decoded.append(t)
+
+        return decoded
+
+
+def sample_top_p(probs, p):
+    probs_sort, probs_idx = torch.sort(probs, dim=-1, descending=True)
+    probs_sum = torch.cumsum(probs_sort, dim=-1)
+    mask = probs_sum - probs_sort > p
+    probs_sort[mask] = 0.0
+    probs_sort.div_(probs_sort.sum(dim=-1, keepdim=True))
+    next_token = torch.multinomial(probs_sort, num_samples=1)
+    next_token = torch.gather(probs_idx, -1, next_token)
+    return next_token
+
+
+class ModelArgs:
+    def __init__(self, path: str):
+        with open(path, "r") as f:
+            params = yaml.load(f, Loader=Loader)
+        for k, v in params.items():
+            setattr(self, k, v)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--checkpoint", default="")
+    # TODO: Make this take as input --model-config, similar to generate.py
+    parser.add_argument("--params", default="")
+    parser.add_argument("--wandb-dir", default="")
+    parser.add_argument("--input-text", required=True)
+    parser.add_argument("--max-gen-len", default=200, type=int)
+    parser.add_argument("--temperature", default=0.8, type=float)
+    parser.add_argument("--top-p", default=0.95, type=float)
+
+    args = parser.parse_args()
+
+    if args.wandb_dir != "":
+        if args.params == "":
+            args.params = os.path.join(args.wandb_dir, "params.txt")
+        if args.checkpoint == "":
+            chkpt_dir = os.path.join(args.wandb_dir, "checkpoints", "epoch_*.pt")
+            list_of_files = glob.glob(chkpt_dir)
+            latest_file = max(list_of_files, key=os.path.getctime)
+            args.checkpoint = latest_file
+    else:
+        assert args.params != "", "Must provide params file or a wandb directory."
+        assert args.checkpoint != "", "Must provide checkpoint file or a wandb directory."
+
+    checkpoint = torch.load(args.checkpoint)
+    open_lm = create_model(ModelArgs(args.params)).half()
+
+    state_dict = checkpoint["state_dict"]
+    state_dict = {x.replace("module.", ""): y for x, y in state_dict.items()}
+    open_lm.load_state_dict(state_dict)
+    open_lm.eval().cuda()
+    generator = Generator(open_lm)
+    input_text = [
+        args.input_text,
+    ]
+    output = generator.generate(
+        input_text,
+        GenerationArgs(args.max_gen_len, args.temperature, args.top_p),
+    )
+    print("".join(output))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR adds two generation scripts. One works with a HuggingFace wrapper (giving access to all of HF `generate`) functionality, and the other is a manual decoding script (initially from @gabrielilharco, then modified by @mitchellnw and @jmercat). I'm PR'ing both as they are useful for complementary purposes, and can help debug each other. Right now, the two scripts return the same outputs when `--temperature` is set to 0, and similar outputs (qualitatively) when temperature is not 0.

In addition, this PR fixes an important bug in our HF wrapper: We were enabling embedding weight tying by default even when our input and output embeddings were trained to be different. This PR fixes that in the first commit.