### PR TITLE
Replaced pile -> wikipedia in quickstart instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,21 +23,15 @@ Some considerations:
 - We like [WandB](https://wandb.ai/) and [tensorboard](https://www.tensorflow.org/tensorboard) for logging. We specify how to use these during training below.
 
 ## Process Training Data
-Next you must specify a collection of tokenized data. For the purposes of this example, we will use the [Pile dataset](https://the-eye.eu/public/AI/pile/train/). If you want to download this locally, here's a bash incantation to do this (you'll likely want to do this in a detached screen, preferably overnight).
+Next you must specify a collection of tokenized data. For the purposes of this example, we will use a recent dump of english Wikipedia, available on HuggingFace. To download this locally, we've included a script located at [datapreprocess/wiki_download.py](#datapreprocess/wiki_download.py). All you have to do is specify an output directory for where the raw data should be stored:
 ```
-#!/bin/bash
-mkdir raw_data    ### or wherever you want to store raw data
-cd raw_data
-for i in {0..29}; do  ### change 0..29 if you want fewer files
-  url=$(printf "https://the-eye.eu/public/AI/pile/train/%02d.jsonl.zst" "$i")
-  wget $url
-done
+python datapreprocess/wiki_download.py --output-dir path/to/raw_data
 ```
 
 Next we process our training data by running it through a BPE tokenizer and chunk it into chunks of appropriate length. By default we use the tokenizer attached with [GPT-NeoX-20B](https://github.com/EleutherAI/gpt-neox). To do this, use the script `datapreprocess/make_2048.py`:
 ```
 >>> python datapreprocess/make_2048.py \
-    --input-files raw_data/*.jsonl
+    --input-files path_to_raw_data/*.jsonl
     --output-dir preproc_data
     --num-workers 32
     --num-consumers 1

--- a/datapreprocess/wiki_download.py
+++ b/datapreprocess/wiki_download.py
@@ -1,0 +1,32 @@
+""" 
+Quick wikipedia download script from huggingface for quickstart purposes.
+Just downloads the 20220301 english wikipedia from huggingface and 
+does no extra preprocessing.
+
+"""
+
+import argparse
+from datasets import load_dataset #huggingface
+import os
+
+
+def main(output_dir):
+	os.makedirs(output_dir, exist_ok=True)
+	data = load_dataset('wikipedia', '20220301.en')
+
+	for split, dataset in data.items():
+		print("Processing split: %s" % data)
+		output_file = os.path.join(output_dir, 'wiki_en_20220301_%s.jsonl' % (split))
+		dataset.to_json(output_file)
+
+
+
+if __name__ == '__main__':
+	parser = argparse.ArgumentParser()
+	parser.add_argument('--output-dir', type=str, required=True,
+		 			    help="Where to store the wikipedia .jsonl file")
+
+	args = parser.parse_args()
+	main(args.output_dir)
+
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,5 @@ boto3==1.26.90
 Pillow
 zstandard
 llm-foundry
+apache_beam
+datasets


### PR DESCRIPTION
Added a script in dataprocess to download wikipedia from huggingface for use in the quickstart example (since pile went down recently)

Also modded some things in the requirements.txt to make this script work