### PR TITLE
Add HF mixin

### DIFF
--- a/open_lm/model.py
+++ b/open_lm/model.py
@@ -11,6 +11,8 @@ from torch.utils.checkpoint import checkpoint
 
 import xformers.ops as xops
 
+from huggingface_hub import PyTorchModelHubMixin
+
 from open_lm.norms import get_norm_class
 from open_lm.positional_embedding.head_rotary import HeadRotaryWithCast
 from open_lm.positional_embedding.rotary import RotaryWithCast
@@ -173,7 +175,7 @@ class Block(nn.Module):
         return out
 
 
-class Transformer(nn.Module):
+class Transformer(nn.Module, PyTorchModelHubMixin):
     def __init__(self, params):
         super().__init__()
         # for convenience we often share param names with llama

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ zstandard
 llm-foundry
 apache_beam
 datasets
+huggingface_hub


### PR DESCRIPTION
Hi folks,

Congrats on this amazing project!

At HF we do have a Mixin class which is a bit hidden in the docs but it's actually super useful to share models easily on the hub. All you need to do is make sure your class inherits from the [PyTorchModelHubMixin](https://huggingface.co/docs/huggingface_hub/v0.17.3/en/package_reference/mixins#huggingface_hub.PyTorchModelHubMixin) class besides nn.Module, and boom, you automatically get `from_pretrained` and `push_to_hub` for free.

You can now do this:

```
from copy import deepcopy
from open_lm.model import Transformer, Params, _MODEL_CONFIGS
from torch import nn

def get_config(model):
  cfg = deepcopy(_MODEL_CONFIGS[model])
  config = Params(
      dim=cfg["hidden_dim"],
      n_layers=cfg["n_layers"],
      n_heads=cfg["n_heads"],
      seq_len=cfg["seq_len"],
      vocab_size=cfg["vocab_size"],
      post_embed_norm=cfg["post_embed_norm"],
      weight_tying=cfg["weight_tying"],
      norm_type=nn.LayerNorm,
      apply_qk_norm=False,
      rotary_old=False,
  )
  return config

config = get_config(model="open_lm_11m")
model = Transformer(config)

# push to HF hub
model.push_to_hub("mlfoundations/open_lm_11b")

# reload using the familiar method
reloaded_model = Transformer.from_pretrained("mlfoundations/open_lm_11b", params=config)
```

I've made a [notebook](https://colab.research.google.com/drive/1LqtsCOL-CFbT4U431iPAvb4RuMyaKVWs?usp=sharing) to showcase how it may be helpful for you. I also saw you already have an `OpenLMConfig` class, this could be an alternative (and cleaner) way to store hyperparameters related to the model architecture, which could allow to do:
```
config = OpenLMConfig(n_layers=12, seq_len=512)
model = Transformer(config)
model.push_to_hub("mlfoundations/open_lm_11b")
```
However I've noticed some discrepancies between attribute names in `OpenLMConfig` and the ones defined in the model. HF Transformers for instance makes sure both are aligned.

Oh and there's more: it comes with automatic download counts, meaning that you can easily track how many times each of the model variants get downloaded.

Happy to discuss more!

Cheers,

Niels
ML @ HF

