### PR TITLE
Mup

### DIFF
--- a/open_lm/main.py
+++ b/open_lm/main.py
@@ -471,7 +471,7 @@ def main(args):
 
         if args.mup_base_model != "None":
             # assume mup is a path to a base model
-            logging.info("Using mu parameterization with based model ",args.mup_base_model)
+            logging.info("Using mu parameterization with base model ",args.mup_base_model)
             class ModelArgs():
                 def __init__(self, model):
                     self.model = model

--- a/open_lm/main.py
+++ b/open_lm/main.py
@@ -401,6 +401,11 @@ def main(args):
 
     if args.distributed:
         if args.fsdp:
+            # if we use mup, we use different learning rates for the parameters, 
+            # so we can't allow fsdp to put different parameters together
+            if args.mup_base_dim:
+                assert (args.fsdp_use_orig_params), "For mu-parameterization, the flag --fsdp-use-orig-params should be set."
+
             # from https://pytorch.org/blog/efficient-large-scale-training-with-pytorch/
             transformer_auto_wrapper_policy = functools.partial(
                 transformer_auto_wrap_policy,

--- a/open_lm/main.py
+++ b/open_lm/main.py
@@ -480,8 +480,7 @@ def main(args):
             base_model = create_model(ModelArgs(args.mup_base_model)) 
             weight_multipliers = compute_mup_multiplier(model,base_model)
 
-            # need to fix weight decay in MuAdam
-            optimizer = MuAdam(model.named_parameters(),weight_multipliers,optim.AdamW, lr=args.lr)
+            optimizer = MuAdam(model.named_parameters(),weight_multipliers,optim.AdamW, lr=args.lr,weight_decay=args.wd)
 
         else:
             optimizer = optim.AdamW(

--- a/open_lm/main.py
+++ b/open_lm/main.py
@@ -482,6 +482,9 @@ def main(args):
 
             optimizer = MuAdam(model.named_parameters(),weight_multipliers,optim.AdamW, lr=args.lr,weight_decay=args.wd)
 
+        elif args.muparam:
+            optimizer = FullMuAdam(model.named_parameters(), optim.AdamW, lr=args.lr, weight_decay=args.wd)
+
         else:
             optimizer = optim.AdamW(
                 [

--- a/open_lm/model.py
+++ b/open_lm/model.py
@@ -254,6 +254,6 @@ def create_model(args):
         weight_tying=cfg["weight_tying"],
         norm_type=get_norm_class(args),
         apply_qk_norm=args.qk_norm,
-        rotary_old=args.rotary_old
+        #rotary_old=args.rotary_old
     )
     return Transformer(args)

--- a/open_lm/model.py
+++ b/open_lm/model.py
@@ -138,7 +138,7 @@ class CustomAttn(nn.Module):
             '''
             base_head_dim = self.mup_base_dim // self.mup_base_n_heads
             multiplier = 1 / (self.head_dim / base_head_dim)
-            output = self.attn_fn(queries, keys, vals, is_causal=is_causal) * float(multiplier)
+            output = self.attn_fn(queries, keys * float(multiplier), vals, is_causal=is_causal) 
         else:
             output = self.attn_fn(queries, keys, vals, is_causal=is_causal)
 
@@ -280,6 +280,6 @@ def create_model(args):
         apply_qk_norm=args.qk_norm,
         mup_base_dim=args.mup_base_dim,
         mup_base_n_heads=args.mup_base_n_heads,
-        #rotary_old=args.rotary_old
+        rotary_old=args.rotary_old
     )
     return Transformer(args)

--- a/open_lm/model_configs/open_lm_41m.json
+++ b/open_lm/model_configs/open_lm_41m.json
@@ -1,0 +1,9 @@
+{
+    "hidden_dim": 288,
+    "n_layers": 12,
+    "n_heads": 12,
+    "seq_len": 2048,
+    "vocab_size": 50432,
+    "post_embed_norm": false,
+    "weight_tying": false
+}

--- a/open_lm/params.py
+++ b/open_lm/params.py
@@ -217,20 +217,11 @@ def parse_args(args):
         help="Name of the transformer to use.",
     )
     parser.add_argument(
-        "--mup_base_model",
-        type=str,
-        default="None",
-        help="Name of the base model for muparameterization to use. If none, don't use mu parameterization.",
+        "--mup_base_dim",
+        type=int,
+        default=0,
+        help="Parameter dim for muparameterization to use. If 0, do not use mu parameterization.",
     )
-
-        parser.add_argument(
-        "--muparam",
-        action='store_true',
-        default=False,
-        help="Name of the base model for muparameterization to use. If none, don't use mu parameterization.",
-    )
-
-
     parser.add_argument(
         "--model-norm",
         type=str,

--- a/open_lm/params.py
+++ b/open_lm/params.py
@@ -223,6 +223,12 @@ def parse_args(args):
         help="Parameter dim for muparameterization to use. If 0, do not use mu parameterization.",
     )
     parser.add_argument(
+        "--mup_base_n_heads",
+        type=int,
+        default=0,
+        help="Parameter n_heads for muparameterization to use. If 0, assume dim_head doesn't change.",
+    )
+    parser.add_argument(
         "--model-norm",
         type=str,
         default="default_layer_norm",

--- a/open_lm/params.py
+++ b/open_lm/params.py
@@ -223,6 +223,13 @@ def parse_args(args):
         help="Name of the base model for muparameterization to use. If none, don't use mu parameterization.",
     )
 
+        parser.add_argument(
+        "--muparam",
+        action='store_true',
+        default=False,
+        help="Name of the base model for muparameterization to use. If none, don't use mu parameterization.",
+    )
+
 
     parser.add_argument(
         "--model-norm",

--- a/open_lm/params.py
+++ b/open_lm/params.py
@@ -214,8 +214,16 @@ def parse_args(args):
         "--model",
         type=str,
         default="m1b_neox",
-        help="Name of the vision backbone to use.",
+        help="Name of the transformer to use.",
     )
+    parser.add_argument(
+        "--mup_base_model",
+        type=str,
+        default="None",
+        help="Name of the base model for muparameterization to use. If none, don't use mu parameterization.",
+    )
+
+
     parser.add_argument(
         "--model-norm",
         type=str,

--- a/open_lm/train.py
+++ b/open_lm/train.py
@@ -294,14 +294,24 @@ def compute_mup_multiplier(model,base_model):
     for param_name, param in model.named_parameters():
         if len(param.shape) == 2:
             if 'output' not in param_name and 'embedding' not in param_name:
-                if param_name not in base_shapes:
+                # The parameters of a (Distributed)DataParallel module all have names that
+                # start with 'module'. This causes a mismatch from non-DataParallel modules.
+                # The code below tries to match the base shapes to shapes by allowing the 
+                # names to start with 'module' or not.
+                if param_name in base_shapes:
+                    weight_multipliers[param_name] = param.shape[1] / base_shapes[param_name][1]
+                elif param_name.split('module.')[1] in base_shapes:
+                    weight_multipliers[param_name] = param.shape[1] / base_shapes[ param_name.split('module.')[1] ][1]
+                elif 'module.' + param_name in base_shapes:
+                    weight_multipliers[param_name] = param.shape[1] / base_shapes['module.' + param_name][1]
+                else:
                     raise KeyError(f"'{param_name}' not found in base model")
                 # multiplier is the ratio of the fanin of the current model to the base model
-                weight_multipliers[param_name] = param.shape[1] / base_shapes[param_name][1]
+                
         elif len(param.shape) > 2:
             raise NotImplementedError('more than 2 inf dimensions')
+
     return weight_multipliers
-    # make parameter groups
 
 def MuAdam(named_params, weight_multipliers, impl, decoupled_wd=False, **kwargs):
     
@@ -324,33 +334,11 @@ def MuAdam(named_params, weight_multipliers, impl, decoupled_wd=False, **kwargs)
         The following checks if the parameter is a matrix like weight, and if 
         yes adds it to the matrix_like_p dictionary, 
         else adds it to the vector_like_p dictionary
+        '''
         if param_name in weight_multipliers: # we have a match of parameter names
-           matrix_like_p[ weight_multipliers[param_name] ]['params'].append(p)
+            matrix_like_p[ weight_multipliers[param_name] ]['params'].append(p)
         else:
             vector_like_p['params'].append(p)
-
-        The parameters of a (Distributed)DataParallel module all have names that
-        start with 'module'. This causes a mismatch from non-DataParallel modules.
-        The code below tries to match the base shapes to shapes by allowing the 
-        names to start with 'module' or not.
-
-        '''
-        if param_name.startswith('module.'):
-            param_name_striped = param_name.split('module.')[1] # remove 'module.' from the name
-            if param_name in weight_multipliers:
-                matrix_like_p[ weight_multipliers[param_name] ]['params'].append(p)
-            elif param_name_striped in weight_multipliers:
-                matrix_like_p[ weight_multipliers[param_name_striped] ]['params'].append(p)
-            else:
-                vector_like_p['params'].append(p)
-        else:
-            param_name_append_module = 'module.' + param_name
-            if param_name in weight_multipliers:
-                matrix_like_p[ weight_multipliers[param_name] ]['params'].append(p)
-            elif param_name_append_module in weight_multipliers:
-                matrix_like_p[ weight_multipliers[param_name_append_module] ]['params'].append(p)
-            else:
-                vector_like_p['params'].append(p)
    
     for width_mult, group in matrix_like_p.items():
         # Scale learning rate and weight decay accordingly
@@ -362,4 +350,4 @@ def MuAdam(named_params, weight_multipliers, impl, decoupled_wd=False, **kwargs)
         new_param_groups.extend(list(matrix_like_p.values()) + [vector_like_p])
     
     return impl(new_param_groups, **kwargs)
-
+    


### PR DESCRIPTION
This is an implementation for mu parameterization following 
[1] Table 8 in http://arxiv.org/abs/2309.16620 for Adam
The  parameterization scales starting from the parameters of an existing based model. 

If the parameter   --mup_base_dim [int] is given, the model model is modified following [1] as follows:
- To change the initialization variables of the output weights to be constant [1], we fix them to 1/mup_base_dim 
- To scale the output with 1/fan_in, we multiply the output with 1 / (fan_in / base_fan_in)
- To change the learning rates of the matrix-like parameters, apart from the embedding and output layers to be 1/fan_in, we scale them with 1 / (fan_in / base_fan_in)
For our parameterization of the transformer this only requires mup_base_dim.

If the parameter   --mup_base_n_heads [int] is given, we also do, following [1]:
- To scale the attention logits with 1/head_dim, we scale them as 1/sqrt(base_head_dim) * 1/ (head_dim/base_head_dim). 
If this parameter is not given, we do not scale the attention logits, if we keep head_dim constant this still follows mu parametrization. 

We could also add Mitchel's mup_simple (http://arxiv.org/abs/2309.14322) as an option, this would be a very simple modification, we would only change the learning rates, but not the scales in the model itself.
  