### PR TITLE
Support for fused cross entropy

### DIFF
--- a/open_lm/main.py
+++ b/open_lm/main.py
@@ -29,6 +29,7 @@ from torch.distributed.fsdp import (
     ShardingStrategy,
 )
 from torch.distributed.fsdp.wrap import transformer_auto_wrap_policy
+from flash_attn.losses.cross_entropy import CrossEntropyLoss as FusedCrossEntropyLoss
 
 from .model import Block
 from .losses import CrossEntropyLossWithZLoss
@@ -566,8 +567,12 @@ def main(args):
 
         return
 
-    loss = torch.nn.CrossEntropyLoss()
+    if args.fused_xent:
+        loss = FusedCrossEntropyLoss()
+    else:
+        loss = torch.nn.CrossEntropyLoss()
     if args.z_loss_coefficient != 0.0:
+        assert not args.fused_xent
         if is_master(args):
             logging.info("Using CrossEntropyLossWithZLoss.")
         loss = CrossEntropyLossWithZLoss(args.z_loss_coefficient)

--- a/open_lm/params.py
+++ b/open_lm/params.py
@@ -166,6 +166,9 @@ def parse_args(args):
         "--warmup", type=int, default=10000, help="Number of steps to warmup for."
     )
     parser.add_argument(
+        "--fused-xent", action="store_true", default=False, help="Whether to use fused cross entropy"
+    )
+    parser.add_argument(
         "--z-loss-coefficient",
         type=float,
         default=0.0,


### PR DESCRIPTION
As in https://github.com/mosaicml/llm-foundry/blob/7f7c0979f8b2c7d95ce634f29fe417464d983410/llmfoundry/models/mpt/modeling_mpt.py#L722-L727

In a couple informal tests, I didn't see significant wins on a 1B model on 8 A100s (12997 tok/s/gpu -> 13092 t/s/g), but adding so we have support and can test on larger models later for speed improvements. 