### PR TITLE
Remove fused cross-entropy

### DIFF
--- a/open_lm/main.py
+++ b/open_lm/main.py
@@ -26,10 +26,8 @@ from torch.distributed.fsdp import (
     FullStateDictConfig,
     StateDictType,
     CPUOffload,
-    ShardingStrategy,
 )
 from torch.distributed.fsdp.wrap import transformer_auto_wrap_policy
-from flash_attn.losses.cross_entropy import CrossEntropyLoss as FusedCrossEntropyLoss
 
 from .model import Block
 from .losses import CrossEntropyLossWithZLoss
@@ -574,12 +572,8 @@ def main(args):
 
         return
 
-    if args.fused_xent:
-        loss = FusedCrossEntropyLoss()
-    else:
-        loss = torch.nn.CrossEntropyLoss()
+    loss = torch.nn.CrossEntropyLoss()
     if args.z_loss_coefficient != 0.0:
-        assert not args.fused_xent
         if is_master(args):
             logging.info("Using CrossEntropyLossWithZLoss.")
         loss = CrossEntropyLossWithZLoss(args.z_loss_coefficient)

--- a/open_lm/params.py
+++ b/open_lm/params.py
@@ -167,9 +167,6 @@ def parse_args(args):
         "--warmup", type=int, default=10000, help="Number of steps to warmup for."
     )
     parser.add_argument(
-        "--fused-xent", action="store_true", default=False, help="Whether to use fused cross entropy"
-    )
-    parser.add_argument(
         "--z-loss-coefficient",
         type=float,
         default=0.0,

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,4 +14,3 @@ llm-foundry
 apache_beam
 datasets
 huggingface_hub
-flash_attn


### PR DESCRIPTION
Upon further testing, fused cross entropy only adds a ~1% speedup, but requires adding a dependency on flash_attn and fails for certain param/batch size combinations (e.g., fails at 1B with bs=32 with inscrutable errors). For simplicity, we've decided not to use it given the minor improvements.