### PR TITLE
Fix optim_state_dict_to_load call for latest pytorch versions

### DIFF
--- a/open_lm/main.py
+++ b/open_lm/main.py
@@ -133,7 +133,7 @@ def load_optimizer(args, model, optimizer, scaler):
         if optimizer is not None:
             osd = checkpoint["optimizer"]
             if args.fsdp:
-                osd = FSDP.optim_state_dict_to_load(osd, model, optimizer)
+                osd = FSDP.optim_state_dict_to_load(model=model, optim=optimizer, optim_state_dict=osd)
             optimizer.load_state_dict(osd)
             logging.info(f"=> resuming optimizer")
         if scaler is not None and "scaler" in checkpoint:


### PR DESCRIPTION
PyTorch changed the order of the arguments for optim_state_dict_to_load, resulting in confusing error messages when loading checkpoints. This commit fixes that issue. See

Pytorch issue: https://github.com/pytorch/pytorch/issues/105727
Commit that introduced the issue: https://github.com/pytorch/pytorch/commit/580b4702bc862dbce386312900db985df58428c0#diff-ffc1ad1876fbf03d814108f6f2f5950a99281b47e0fd77597745f10dc99add86R1822-R1827
Sample fix: https://github.com/huggingface/accelerate/pull/1755