### PR TITLE
Log and skip errors in map_dict

### DIFF
--- a/open_lm/data.py
+++ b/open_lm/data.py
@@ -388,10 +388,11 @@ def get_wds_dataset(
                 ]
             )
 
+        map_dict_handler = {"handler": log_and_continue} if args.ignore_parse_errors else {}
         if data_key == "json":
             pipeline.extend(
                 [
-                    wds.map_dict(json=partial(preprocess_json, vocab_size=args.vocab_size)),
+                    wds.map_dict(json=partial(preprocess_json, vocab_size=args.vocab_size), **map_dict_handler),
                     wds.to_tuple("json"),
                     wds.select(partial(filter_lt_seqlen, args.seq_len)),
                     wds.batched(args.batch_size, partial=not is_train),
@@ -400,7 +401,7 @@ def get_wds_dataset(
         else:
             pipeline.extend(
                 [
-                    wds.map_dict(txt=partial(preprocess_txt, vocab_size=args.vocab_size)),
+                    wds.map_dict(txt=partial(preprocess_txt, vocab_size=args.vocab_size), **map_dict_handler),
                     wds.to_tuple("txt"),
                     wds.select(partial(filter_lt_seqlen, args.seq_len)),
                     wds.batched(args.batch_size, partial=not is_train),

--- a/open_lm/params.py
+++ b/open_lm/params.py
@@ -480,6 +480,12 @@ def parse_args(args):
         default=False,
         help="If true, will end training early if the desired token count is reached. Requires --no-skip-tokens.",
     )
+    parser.add_argument(
+        "--ignore-parse-errors",
+        action="store_true",
+        default=False,
+        help="If true, ignore parse errors in data loading. This should ideally be False, as errors in dataloading can point to bigger issues in your dataset. However, this can be useful when training on a large dataset which has a couple errors."
+    )
 
     add_model_args(parser)
 

--- a/tests/shared.py
+++ b/tests/shared.py
@@ -62,6 +62,7 @@ class MockTrainArgs:
         self.dataset_manifest = None
         self.target_mask_left = None
         self.target_mask_individual = None
+        self.ignore_parse_errors = False
 
 
 class MockDataArgs(object):


### PR DESCRIPTION
Some webdataset files have json issues that throw an error and break training, this logs and skips them instead.