### PR TITLE
added 41m model config

### DIFF
--- a/open_lm/model_configs/open_lm_41m.json
+++ b/open_lm/model_configs/open_lm_41m.json
@@ -1,0 +1,9 @@
+{
+    "hidden_dim": 288,
+    "n_layers": 12,
+    "n_heads": 12,
+    "seq_len": 2048,
+    "vocab_size": 50432,
+    "post_embed_norm": false,
+    "weight_tying": false
+}


### PR DESCRIPTION
Added a 41m model config; we get relatively reliable scaling starting from the 41m model, and the model lies between the 25m and the 87m model, specifically, the model has 41.01m parameters and 11.94m non-embedding parameters, while those numbers are 24.68m and 5.31m for the 25m model and 87.47m and 38.23m for the 87m model.