### PR TITLE
Fix naming inconsistencies.

### DIFF
--- a/open_lm/file_utils.py
+++ b/open_lm/file_utils.py
@@ -169,7 +169,7 @@ def get_string_for_epoch(num_samples, starting_chunk, paths, weights, min_shards
     for i, source_path in enumerate(paths):
         shard_list_source = shard_list_per_source[i]
         num_samples_source = num_samples_per_source[i]
-        shard_root_source = '/'.join(source_path.split('/')[:-1]) + '/shard_'
+        shard_root_source = '/'.join(source_path.split('/')[:-1]) + '/'
         shard_string_source = shard_root_source + '{' + ",".join(shard_list_source) + '}.tar'
         if source_path.startswith('s3'):
             shard_string_source = f'pipe:aws s3 cp {shard_string_source} -'

--- a/open_lm/utils/make_wds_manifest.py
+++ b/open_lm/utils/make_wds_manifest.py
@@ -54,7 +54,7 @@ def worker_fn(input_data):
     basename, data_dir, tmp_dir = input_data
     shard_path = data_dir / basename
     return (basename, {
-        "shard": basename.split("_")[1].split(".")[0],
+        "shard": basename.split(".")[0],
         "num_chunks": count_samples(shard_path, tmp_dir),
     })
 


### PR DESCRIPTION
Fix some naming inconsistencies between manifests and the dataloader. This should work with arbitrary shard names.