### PR TITLE
Fix sample/step counting in the case of uneven epochs.

### DIFF
--- a/open_lm/main.py
+++ b/open_lm/main.py
@@ -678,6 +678,10 @@ def main(args):
                         for i in range(len(args.train_data_mix_weights))
                     ]
                     chosen_num_samples = remaining_samples_per_source
+                    logging.info(
+                        "Model has seen the desired number of tokens. Running one final epoch."
+                    )
+                    final_epoch = True
                 else:
                     chosen_num_samples = num_samples_per_source
             else:
@@ -685,16 +689,7 @@ def main(args):
 
             data["train"] = get_wds_dataset(
                 args, True, epoch, force_num_samples=chosen_num_samples, data_key=args.data_key,
-            )
-
-            if (
-                args.accurate_total_tokens
-                and samples_seen >= args.epochs * args.train_num_samples
-            ):
-                logging.warning(
-                    "Model has seen the desired number of tokens. Running one final epoch."
-                )
-                final_epoch = True
+            )                
 
         try:
             prev_step = int(optimizer.state_dict()["state"][0]["step"].item())

--- a/open_lm/main.py
+++ b/open_lm/main.py
@@ -678,13 +678,10 @@ def main(args):
                         for i in range(len(args.train_data_mix_weights))
                     ]
                     chosen_num_samples = remaining_samples_per_source
-                    samples_seen = samples_seen + sum(chosen_num_samples)
                 else:
                     chosen_num_samples = num_samples_per_source
-                    samples_seen = samples_seen + sum(chosen_num_samples)
             else:
                 chosen_num_samples = None
-                samples_seen = samples_seen + args.train_num_samples
 
             data["train"] = get_wds_dataset(
                 args, True, epoch, force_num_samples=chosen_num_samples, data_key=args.data_key,
@@ -698,6 +695,11 @@ def main(args):
                     "Model has seen the desired number of tokens. Running one final epoch."
                 )
                 final_epoch = True
+
+        try:
+            prev_step = int(optimizer.state_dict()["state"][0]["step"].item())
+        except KeyError:
+            prev_step = 0
 
         if args.distributed:
             dist.barrier()
@@ -716,6 +718,9 @@ def main(args):
 
         if args.distributed:
             dist.barrier()
+
+        steps_done_epoch = int(optimizer.state_dict()["state"][0]["step"].item()) - prev_step
+        samples_seen = samples_seen + steps_done_epoch * args.batch_size * args.world_size
 
         if not success:
             logging.info(f"Training exiting due to NaN value")

--- a/open_lm/train.py
+++ b/open_lm/train.py
@@ -122,7 +122,12 @@ def train_one_epoch(
     end = time.time()
 
     for i, batch in enumerate(dataloader):
-        step = num_batches_per_epoch * epoch + i
+        try:
+            step = int(optimizer.state_dict()["state"][0]["step"].item())
+        except KeyError:
+            # Throws keyerror if it is the first step
+            step = 0
+
         if not args.skip_scheduler:
             scheduler(step)
 


### PR DESCRIPTION
This fixes #65 - step counting during training was implicitly assuming that all epochs had the same number of steps, which might not hold when using `--no-skip-tokens` and `--accurate-total-tokens`.