### PR TITLE
Add params to MockArgs

### DIFF
--- a/tests/shared.py
+++ b/tests/shared.py
@@ -55,6 +55,8 @@ class MockTrainArgs:
         self.positional_embedding_type = "rotary"
         self.dist_backend = "nccl"
         self.dist_url = "env://"
+        self.dataset_manifest = None
+        self.target_mask_left = None
 
 
 class MockDataArgs(object):


### PR DESCRIPTION
Fixes grad_accum tests so they pass again:

```
tests/test_grad_accum.py::test_grad_acc PASSED                                                                                                                                                                                                                
tests/test_grad_accum.py::test_grad_acc_fsdp PASSED
tests/test_target_masking.py::test_create_replace_before_tok PASSED
```

(The data tests require an assets folder and fail right now unrelated to this PR)