### PR TITLE
data.py: only x%vocab_size when x < 0

### DIFF
--- a/open_lm/data.py
+++ b/open_lm/data.py
@@ -38,7 +38,7 @@ from webdataset.mix import RandomMix
 
 def proc_token(x, vocab_size):
     if type(x) is int:
-        return x % vocab_size
+        return x % vocab_size if x < 0 else x
 
     # FIXME: currently assuming that if not an int 0 is an appropriate token.
     # probably want to throw an error here instead. leaving as 0 for now for


### PR DESCRIPTION
reason for this is - if you're trying out data tokenized with a higher vocab size than you expect this will silently fail and make the data wrong