### PR TITLE
Fill-in-the-middle training

### DIFF
--- a/open_lm/params.py
+++ b/open_lm/params.py
@@ -174,6 +174,13 @@ def parse_args(args):
     parser.add_argument("--eps", type=float, default=None, help="Adam epsilon.")
     parser.add_argument("--wd", type=float, default=0.2, help="Weight decay.")
     parser.add_argument("--warmup", type=int, default=10000, help="Number of steps to warmup for.")
+
+    parser.add_argument("--tokenizer", type=str, default="EleutherAI/gpt-neox-20b", help="Only used for FIM")
+    parser.add_argument("--fim-rate", type=float, default=0, help="Percentage of fill-in-middle")
+    parser.add_argument("--fim-prefix-token", type=str, default="<prefix>", help="Token to indicate prefix in FIM")
+    parser.add_argument("--fim-suffix-token", type=str, default="<suffix>", help="Token to indicate suffix in FIM")
+    parser.add_argument("--fim-middle-token", type=str, default="<middle>", help="Token to indicate middle in FIM")
+
     parser.add_argument(
         "--z-loss-coefficient",
         type=float,

--- a/tests/test_fim_permute.py
+++ b/tests/test_fim_permute.py
@@ -1,0 +1,50 @@
+import numpy as np
+from open_lm.train import permute_segment
+
+
+def test_resize_token_embeddings():
+    prefix_tok_id = 9999
+    suffix_tok_id = 9998
+    middle_tok_id = 9997
+
+    test_cases = [
+        (np.array(range(100)), 1.0),
+        (np.array(range(2000)), 0.0),
+        (np.random.choice(2000, 500), 1.0),
+        (np.random.choice(9876, 888), 0.0),
+        (np.random.choice(9000, 9000), 1.0),
+    ]
+
+    for sample, fim_rate in test_cases:
+        new_sample = permute_segment(sample, fim_rate, prefix_tok_id, suffix_tok_id, middle_tok_id)
+
+        if fim_rate == 0.0:
+            assert (new_sample == sample).all()
+
+        if fim_rate == 1.0:
+            prefix_idx = np.argwhere(new_sample == prefix_tok_id)
+            suffix_idx = np.argwhere(new_sample == suffix_tok_id)
+            middle_idx = np.argwhere(new_sample == middle_tok_id)
+
+            assert len(prefix_idx) == 1
+            assert len(suffix_idx) == 1
+            assert len(middle_idx) == 1
+
+            assert prefix_idx[0][0] == 0
+            assert prefix_idx[0][0] <= suffix_idx[0][0]
+            assert suffix_idx[0][0] <= middle_idx[0][0]
+            assert middle_idx[0][0] <= new_sample.shape[0]
+
+    # Test that the fim_rate frequency works as expected
+    test_cases_2 = []
+    n = 10000
+    for i in range(n):
+        test_cases_2.append(np.random.choice(5000, 5000))
+
+    diff_counter = 0
+    for sample in test_cases_2:
+        new_sample = permute_segment(sample, 0.2, prefix_tok_id, suffix_tok_id, middle_tok_id)
+        if (new_sample == sample).all() == False:
+            diff_counter += 1
+    fim_changed = diff_counter / n
+    assert fim_changed >= 0.19 and fim_changed <= 0.21

--- a/tests/test_resize_token_embeddings.py
+++ b/tests/test_resize_token_embeddings.py
@@ -1,0 +1,30 @@
+import torch
+from transformers import GPTNeoXTokenizerFast
+from tests.shared import MockTrainArgs
+from open_lm.model import create_model
+
+
+def test_resize_token_embeddings():
+    args = MockTrainArgs("open_lm_11m")
+
+    tokenizer = GPTNeoXTokenizerFast.from_pretrained("EleutherAI/gpt-neox-20b")
+    num_tokens_old = len(tokenizer)
+    for i in range(300):
+        tokenizer.add_tokens(f"<<{str(i)}>>")
+
+    model = create_model(args).to(args.device)
+    emb_in_old = model.get_input_embeddings().weight
+    emb_out_old = model.get_output_embeddings().weight
+
+    model.resize_token_embeddings(len(tokenizer))
+
+    new_shape_in = model.get_input_embeddings().weight.shape
+    new_shape_out = model.get_output_embeddings().weight.shape
+
+    # Check shapes
+    assert num_tokens_old + 300 == new_shape_in[0]
+    assert num_tokens_old + 300 == new_shape_out[0]
+
+    # Check values
+    assert torch.sum(model.get_input_embeddings().weight[: emb_in_old.shape[0], :] - emb_in_old) < 0.00001
+    assert torch.sum(model.get_output_embeddings().weight[: emb_out_old.shape[0], :] - emb_out_old) < 0.00001


### PR DESCRIPTION
Implements fill-in-the-middle training according to the [OpenAI FIM paper](https://arxiv.org/abs/2207.14255) and based on BigCode's Megatron FIM [implementation](https://github.com/bigcode-project/Megatron-LM/blob/bd0aaba3492b441d7f186bb1159fc21e1dcd7a72/megatron/data/gpt_dataset.py#L684)

I've tested this and verified that it behaves as expected. Next step would be to use it to train a model and see how it performs.

I also implemented model.resize_token_embeddings, which I initially thought we would need since we're adding new special tokens for FIM, but seems like it's not necessary since our model vocab > token vocab, so we have room to spare for new tokens.

Usage: Simply supply a value for `--fim_rate` (default is 0).   
