### PR TITLE
Shared epoch common for datasets.

### DIFF
--- a/open_lm/data.py
+++ b/open_lm/data.py
@@ -312,6 +312,7 @@ def get_wds_dataset(
 
     datasets = []
     all_num_samples = []
+    shared_epoch = SharedEpoch(epoch=epoch)  # create a shared epoch store to sync epoch to dataloader worker proc
     for ii, input_shards in enumerate(input_shards_):
         resampled = getattr(args, "dataset_resampled", False) and is_train
 
@@ -335,8 +336,6 @@ def get_wds_dataset(
         else:
             # Eval will just exhaust the iterator if the size is not specified.
             num_samples = args.val_num_samples or 0
-
-        shared_epoch = SharedEpoch(epoch=epoch)  # create a shared epoch store to sync epoch to dataloader worker proc
 
         if resampled:
             pipeline = [

--- a/tests/shared.py
+++ b/tests/shared.py
@@ -87,6 +87,7 @@ class MockDataArgs(object):
         self.dataset_manifest = None
         self.target_mask_left = None
         self.target_mask_individual = None
+        self.ignore_parse_errors = False
 
 
 def create_train_fixtures():


### PR DESCRIPTION
This PR makes the shared epoch be common across datasets.

This solves #93 - when updating the dataloader every epoch, only one dataset would get updated, which would make sampling use the same samples for every other dataset (sampling without replacement is not affected by this, since `get_wds_dataset` is called again every epoch).

Results from pytest: 
[tests_fix_shared_epoch.txt](https://github.com/mlfoundations/open_lm/files/13396803/tests_fix_shared_epoch.txt)
