### PR TITLE
Fused implementation of squared loss

### DIFF
--- a/open_lm/activations.py
+++ b/open_lm/activations.py
@@ -1,0 +1,52 @@
+import torch
+import triton
+import triton.language as tl
+
+# Forward Triton kernel
+@triton.jit
+def relu_squared_kernel(X, Y, N, BLOCK_SIZE : tl.constexpr =1024):
+    idx = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = idx < N
+    x = tl.load(X + idx, mask=mask, other=0.0)
+    y = tl.where(x > 0, x*x, 0.0)
+    tl.store(Y + idx, y, mask=mask)
+
+# Backward Triton kernel
+@triton.jit
+def relu_squared_backward_kernel(X, dY, dX, N, BLOCK_SIZE: tl.constexpr=1024):
+    idx = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = idx < N
+    x = tl.load(X + idx, mask=mask, other=0.0)
+    dy = tl.load(dY + idx, mask=mask, other=0.0)
+    dx = tl.where(x > 0, 2 * x * dy, 0.0)
+    tl.store(dX + idx, dx, mask=mask)
+
+# Custom autograd function
+class SquaredReLUFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, input):
+        output = torch.empty_like(input)
+        n_ele = input.numel()
+
+        grid = lambda meta: (triton.cdiv(n_ele, meta['BLOCK_SIZE']), )
+        
+        relu_squared_kernel[grid](input, output, n_ele)
+        ctx.save_for_backward(input)
+        return output
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        input, = ctx.saved_tensors
+        grad_input = torch.empty_like(input)
+        n_ele = input.numel()
+        
+        grid = lambda meta: (triton.cdiv(n_ele, meta['BLOCK_SIZE']), )
+        
+        relu_squared_backward_kernel[grid](input, grad_output, grad_input, n_ele)
+        return grad_input
+
+# To use the custom autograd function
+def squared_relu(input):
+    return SquaredReLUFunction.apply(input)
+
+

--- a/tests/test_squared_relu.py
+++ b/tests/test_squared_relu.py
@@ -1,0 +1,44 @@
+import torch 
+import triton
+import triton.language as tl
+
+from open_lm.activations import squared_relu
+
+
+
+@triton.testing.perf_report(
+    triton.testing.Benchmark(
+        x_names=['size'],  # Argument names to use as an x-axis for the plot.
+        x_vals=[2**i for i in range(12, 28, 1)],  # Different possible values for `x_name`.
+        x_log=True,  # x axis is logarithmic.
+        line_arg='provider',  # Argument name whose value corresponds to a different line in the plot.
+        line_vals=['triton', 'torch'],  # Possible values for `line_arg`.
+        line_names=['Triton', 'Torch'],  # Label name for the lines.
+        styles=[('blue', '-'), ('green', '-')],  # Line styles.
+        ylabel='GB/s',  # Label name for the y-axis.
+        plot_name='vector squared relu performance',  # Name for the plot. Used also as a file name for saving the plot.
+        args={},  # Values for function arguments not in `x_names` and `y_name`.
+    ))
+def benchmark(size, provider):
+    x = torch.rand(size, device='cuda', dtype=torch.float32)
+    quantiles = [0.5, 0.2, 0.8]
+    if provider == 'torch':
+        relu = torch.nn.ReLU()
+        ms, min_ms, max_ms = triton.testing.do_bench(lambda: (relu(x))**2, quantiles=quantiles)
+    if provider == 'triton':
+        ms, min_ms, max_ms = triton.testing.do_bench(lambda: squared_relu(x), quantiles=quantiles)
+    gbps = lambda ms: 12 * size / ms * 1e-6
+    return gbps(ms), gbps(max_ms), gbps(min_ms)
+
+
+def test_squared_relu_perf():
+	benchmark.run(print_data=True, show_plots=True)
+
+def test_squared_relu_correctness(): 
+	torch.manual_seed(0)
+	x = torch.randn(1823, 781, device='cuda')
+	y_triton = squared_relu(x)
+	relu = torch.nn.ReLU()
+	y_torch = (relu(x))**2
+
+	assert torch.allclose(y_triton, y_torch), (y_triton, y_torch)


### PR DESCRIPTION
Fused implementation of squared loss (roughly twice fast when the size of the is large. Here are the benchmarked numbers: 

<img width="576" alt="Screenshot 2023-11-17 at 3 35 32 PM" src="https://github.com/mlfoundations/open_lm/assets/11505019/7841b5c6-2ac8-4fbe-804d-6d4a032a9bdc">


```
vector squared relu performance:
           size       Triton       Torch
0        4096.0     6.000000    4.800000
1        8192.0    13.714286    9.600000
2       16384.0    31.999999   21.333333
3       32768.0    63.999998   48.000000
4       65536.0   127.999995   85.333330
5      131072.0   219.428568  153.600004
6      262144.0   384.000001  279.272725
7      524288.0   558.545450  409.600010
8     1048576.0   819.200021  534.260858
9     2097152.0   910.222221  481.882362
10    4194304.0  1003.102074  522.893602
11    8388608.0  1068.521715  546.133325
12   16777216.0  1104.539313  558.545450
13   33554432.0  1120.273520  564.965515
14   67108864.0  1129.931030  568.642060
15  134217728.0  1134.822544  570.705364
```