### PR TITLE
Support json.gz.

### DIFF
--- a/open_lm/data.py
+++ b/open_lm/data.py
@@ -398,7 +398,7 @@ def get_wds_dataset(
                     wds.select(partial(filter_lt_seqlen, args.seq_len)),
                     wds.batched(args.batch_size, partial=not is_train),
                 ]
-            )  
+            )
         elif data_key == "txt":
             pipeline.extend(
                 [
@@ -407,7 +407,7 @@ def get_wds_dataset(
                     wds.select(partial(filter_lt_seqlen, args.seq_len)),
                     wds.batched(args.batch_size, partial=not is_train),
                 ]
-            )  
+            )
         else:
             raise ValueError(f"Unrecognized data key: {data_key}")
 

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ REQUIREMENTS = _read_reqs("requirements.txt")
 
 setuptools.setup(
     name="open_lm",
-    version="0.0.12",
+    version="0.0.13",
     author=[
         "Suchin Gururangan*",
         "Mitchell Wortsman*",


### PR DESCRIPTION
Decoding was done outside of webdataset, which was not allowing for json.gz items to be loaded.

This PR moves decoding for json files inside the webdataset, and allows for `args.data_key == "json.gz"`.