### PR TITLE
fixed start index in sample_chunk

### DIFF
--- a/open_lm/train.py
+++ b/open_lm/train.py
@@ -88,7 +88,7 @@ def sample_chunk(chunk, args):
     if chunk.shape[1] == args.seq_len + 1:
         start_idx = 0
     elif chunk.shape[1] > args.seq_len + 1:
-        start_idx = torch.randint(0, chunk.shape[1] - args.seq_len + 1, (1,)).item()
+        start_idx = torch.randint(0, chunk.shape[1] - args.seq_len, (1,)).item()
     else:
         raise Exception(f"Invalid sequence length: Sequence length {args.seq_len} > {chunk.shape[1]} Chunk size")
 


### PR DESCRIPTION
faulty line: `start_idx = torch.randint(0, chunk.shape[1] - args.seq_len + 1, (1,)).item()`
if start_idx = chunk.shape[1] - args.seq_len + 1, then:
`targets = chunk[:, start_idx + 1 : start_idx + args.seq_len + 1]` becomes:
```
targets = chunk[:, chunk.shape[1] - args.seq_len + 2 :chunk.shape[1] - args.seq_len + 1 + args.seq_len + 1]
            = chunk[:, chunk.shape[1] - args.seq_len + 2 :chunk.shape[1] + 2]
            = chunk[:, chunk.shape[1] - args.seq_len + 2 :chunk.shape[1]]
```
thus targets sequence shape is < input sequence shape and the loss raises an error.