### PR TITLE
fixed torch_attn that takes dimensions in a different order

### DIFF
--- a/open_lm/model.py
+++ b/open_lm/model.py
@@ -88,7 +88,13 @@ def torch_attn(queries, keys, values, is_causal):
     # Need to call contiguous in torch >=2.1, otherwise later calls to .view() fail.
     # Possibly related: https://github.com/pytorch/pytorch/issues/110213 - behavior of scaled_dot_product_attention
     # changed between 2.0 and 2.1
-    return F.scaled_dot_product_attention(queries, keys, values, is_causal=is_causal).contiguous()
+    return (
+        F.scaled_dot_product_attention(
+            queries.transpose(1, 2), keys.transpose(1, 2), values.transpose(1, 2), is_causal=is_causal
+        )
+        .transpose(1, 2)
+        .contiguous()
+    )
 
 
 def get_pos_embed(args: Params):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -63,8 +63,7 @@ def download_val_data(name: str, root: str = None):
 
 
 def download_dl_test_data(root: str = "./tests/assets"):
-    """Downloads test files if the data doesn't exist in HF cache.
-    """
+    """Downloads test files if the data doesn't exist in HF cache."""
 
     snapshot_args = dict(
         repo_id="mlfoundations/open_lm_test_data",


### PR DESCRIPTION
[F.scaled_dot_produc_attention documentation](https://pytorch.org/docs/2.0/generated/torch.nn.functional.scaled_dot_product_attention.html?highlight=scaled_dot_product_attention#torch.nn.functional.scaled_dot_product_attention)
[xops.memory_efficient_attention documentation](https://facebookresearch.github.io/xformers/components/ops.html?highlight=memory_efficient_attention#xformers.ops.memory_efficient_attention)

The two different attention functions expect input with different dimension orders. I fixed the torch function input dimension order by calling transpose many times.

The "equivalent" code from the xformers  documentation reads `query @ key.transpose(-2, -1)` ( same as the native pytorch one) but it doesn't match their input dimensions specifications... I [raised an issue for that](https://github.com/facebookresearch/xformers/issues/932#issue-2007439731)