### PR TITLE
Reincorporate manifest creation.

### DIFF
--- a/open_lm/datapreprocess/ray/tokenize_shuffle.py
+++ b/open_lm/datapreprocess/ray/tokenize_shuffle.py
@@ -277,11 +277,8 @@ def map_write_wds(batch, batch_size, folder, counter):
     bio.seek(0)
     token_count = ray.get(counter.increment_token_count.remote(token_count))
     write_to_location(folder, tar_name, bio)
-    
-    return_dict = {
-        "shard": [tar_name.split(".")[0]],
-        "num_sequences": [len(batch["tokens"])]
-    }
+
+    return_dict = {"shard": [tar_name.split(".")[0]], "num_sequences": [len(batch["tokens"])]}
 
     return return_dict
 
@@ -465,14 +462,14 @@ if __name__ == "__main__":
         },
         batch_format="pandas",
     )
-    
+
     # Sort by shard name
     ds = ds.repartition(1)
     ds = ds.sort(key="shard")
     ds.write_json(
         args.output.strip("/"),
-        filesystem = fs,
-        block_path_provider = lambda *a, **kw: os.path.join(args.output.rstrip("/"), "manifest.jsonl")
+        filesystem=fs,
+        block_path_provider=lambda *a, **kw: os.path.join(args.output.rstrip("/"), "manifest.jsonl"),
     )
 
     end_time = time.time()

--- a/open_lm/datapreprocess/ray/tokenize_shuffle.py
+++ b/open_lm/datapreprocess/ray/tokenize_shuffle.py
@@ -395,20 +395,16 @@ class GlobalCounter:
 
 def write_manifest(jsonl_lines, args):
     "Write manifest to provided output path."
-    
+
     output_path = os.path.join(args.output.strip("/"), "manifest.jsonl")
 
     if output_path.startswith("s3://"):
         # Use boto3 for S3 paths
         s3_client = boto3.client("s3")
-        jsonl_content = '\n'.join(json.dumps(record) for record in jsonl_lines) + '\n'  # Add a newline at the end
+        jsonl_content = "\n".join(json.dumps(record) for record in jsonl_lines) + "\n"  # Add a newline at the end
         bucket_name, s3_key = output_path[5:].split("/", 1)
-        response = s3_client.put_object(
-            Bucket=bucket_name,
-            Key=s3_key,
-            Body=jsonl_content
-        )
-        if response['ResponseMetadata']['HTTPStatusCode'] != 200:
+        response = s3_client.put_object(Bucket=bucket_name, Key=s3_key, Body=jsonl_content)
+        if response["ResponseMetadata"]["HTTPStatusCode"] != 200:
             logging.warning(
                 "Failed to write manifest. Please manually include manifest by running "
                 "open_lm.utils.make_manifest on the tokenized data."
@@ -417,7 +413,7 @@ def write_manifest(jsonl_lines, args):
         with open(output_path, "w") as f:
             for item in jsonl_lines:
                 json.dump(item, f)
-                f.write('\n')
+                f.write("\n")
 
 
 def main(args):

--- a/open_lm/datapreprocess/ray/tokenize_shuffle.py
+++ b/open_lm/datapreprocess/ray/tokenize_shuffle.py
@@ -401,7 +401,7 @@ def write_manifest(jsonl_lines, args):
     if output_path.startswith("s3://"):
         # Use boto3 for S3 paths
         s3_client = boto3.client("s3")
-        jsonl_content = '\n'.join(json.dumps(record) for record in jsonl_lines)
+        jsonl_content = '\n'.join(json.dumps(record) for record in jsonl_lines) + '\n'  # Add a newline at the end
         bucket_name, s3_key = output_path[5:].split("/", 1)
         response = s3_client.put_object(
             Bucket=bucket_name,
@@ -416,7 +416,7 @@ def write_manifest(jsonl_lines, args):
     else:
         with open(output_path, "w") as f:
             for item in jsonl_lines:
-                f.write(json.dumps(item))
+                json.dump(item, f)
                 f.write('\n')
 
 

--- a/open_lm/datapreprocess/ray/tokenize_shuffle.py
+++ b/open_lm/datapreprocess/ray/tokenize_shuffle.py
@@ -44,6 +44,7 @@ from transformers import GPTNeoXTokenizerFast
 
 import logging
 
+
 class RawFileType(enum.Enum):
     JSONL = 1
     ZSTD_JSONL_COMPRESSED = 2

--- a/tests/test_tokenize_shuffle.py
+++ b/tests/test_tokenize_shuffle.py
@@ -28,9 +28,10 @@ def test_tokenize_shuffle_simple():
     with open("test_output/manifest.jsonl", "rb") as f:
         out = f.read()
     out = [json.loads(o) for o in out.decode("utf-8").split("\n")[:-1]]
-    
+
     assert out[0]["shard"] == "00000001"
     assert out[0]["num_sequences"] == NUM_TOKENS // (content_len + 1)
+
 
 @pytest.mark.parametrize("content_key,NUM_TOKENS", [("npy", 4860228), ("txt", 24588), ("json:duration", 8196)])
 def test_tokenize_shuffle_tar(content_key, NUM_TOKENS):
@@ -86,6 +87,6 @@ def test_tokenize_shuffle_s3_write():
     with open("test_output/manifest.jsonl", "rb") as f:
         out = f.read()
     out = [json.loads(o) for o in out.decode("utf-8").split("\n")[:-1]]
-    
+
     assert out[0]["shard"] == "00000001"
     assert out[0]["num_sequences"] == NUM_TOKENS // (content_len + 1)

--- a/tests/test_tokenize_shuffle.py
+++ b/tests/test_tokenize_shuffle.py
@@ -1,3 +1,4 @@
+import json
 import os
 import pytest
 import webdataset as wds
@@ -24,6 +25,12 @@ def test_tokenize_shuffle_simple():
         total += len(x["json.gz"])
     assert total == NUM_TOKENS
 
+    with open("test_output/manifest.jsonl", "rb") as f:
+        out = f.read()
+    out = [json.loads(o) for o in out.decode("utf-8").split("\n")[:-1]]
+    
+    assert out[0]["shard"] == "00000001"
+    assert out[0]["num_sequences"] == NUM_TOKENS // (content_len + 1)
 
 @pytest.mark.s3
 def test_tokenize_shuffle_s3_write():
@@ -40,3 +47,10 @@ def test_tokenize_shuffle_s3_write():
         total += len(x["json.gz"])
     assert total == NUM_TOKENS
     assert exit_value == 0
+
+    with open("test_output/manifest.jsonl", "rb") as f:
+        out = f.read()
+    out = [json.loads(o) for o in out.decode("utf-8").split("\n")[:-1]]
+    
+    assert out[0]["shard"] == "00000001"
+    assert out[0]["num_sequences"] == NUM_TOKENS // (content_len + 1)

--- a/tests/test_tokenize_shuffle.py
+++ b/tests/test_tokenize_shuffle.py
@@ -14,6 +14,16 @@ def run_around_tests():
 def test_tokenize_shuffle_simple():
     content_len = 2048
     NUM_TOKENS = 381114
+
+    aws_dir = os.path.expanduser("~/.aws")
+
+    # Download dummy creds if they don't exist
+    if not os.path.exists(os.path.join(aws_dir, "credentials")):
+        os.makedirs(aws_dir, exist_ok=True)
+        os.system(
+            f"wget https://gist.githubusercontent.com/Vaishaal/f109bfab6a194a93040ae2a19b6be251/raw/7d8026ae234d77ba1ca29b1f9d114c6780308ae4/dummy_creds -O {aws_dir}/credentials"
+        )        
+
     exit_value = os.system(
         f"python open_lm/datapreprocess/ray/tokenize_shuffle.py --input s3://dcnlp-west-test/tokenize_shuffle_test/C4_V3_tiny/ --content_key content --output test_output/ --seqlen {content_len}"
     )


### PR DESCRIPTION
Add manifest creation in the tokenization script with the new format. The manifests made by this will be compatible with the new dataloader version.