### PR TITLE
Do not enter training loop if done.

### DIFF
--- a/open_lm/main.py
+++ b/open_lm/main.py
@@ -656,7 +656,8 @@ def main(args):
     if args.dataset_manifest:
         log_num_checkpoints(total_steps, args)
 
-    done_training = False
+    # Only enter training loop if there are steps to be done.
+    done_training = global_step >= total_steps
     epoch = start_epoch
     while not done_training:
         if is_master(args):


### PR DESCRIPTION
If attempting to load a fully trained checkpoint, we would previously attempt to save an extra checkpoint.

This will prevent from entering the training loop if the checkpoint we load has already seen the desired number of steps.