### PR TITLE
fix load_model module key edit

### DIFF
--- a/open_lm/main.py
+++ b/open_lm/main.py
@@ -105,9 +105,12 @@ def load_model(args, model):
         start_epoch = checkpoint["epoch"]
         sd = checkpoint["state_dict"]
         global_step = checkpoint.get("step", None)
-        if not args.distributed and next(iter(sd.items()))[0].startswith("module"):
+        if next(iter(sd.items()))[0].startswith("module"):
             sd = {k[len("module.") :]: v for k, v in sd.items()}
-        model.load_state_dict(sd)
+        if args.distributed:
+            model.module.load_state_dict(sd)
+        else:
+            model.load_state_dict(sd)
         logging.info(f"=> resuming checkpoint '{args.resume}' (epoch {start_epoch})")
     else:
         # loading a bare (model only) checkpoint for fine-tune or evaluation

--- a/open_lm/main.py
+++ b/open_lm/main.py
@@ -105,7 +105,7 @@ def load_model(args, model):
         start_epoch = checkpoint["epoch"]
         sd = checkpoint["state_dict"]
         global_step = checkpoint.get("step", None)
-        if next(iter(sd.items()))[0].startswith("module"):
+        if args.distributed and next(iter(sd.items()))[0].startswith("module"):
             sd = {k[len("module.") :]: v for k, v in sd.items()}
         model.load_state_dict(sd)
         logging.info(f"=> resuming checkpoint '{args.resume}' (epoch {start_epoch})")

--- a/open_lm/main.py
+++ b/open_lm/main.py
@@ -105,7 +105,7 @@ def load_model(args, model):
         start_epoch = checkpoint["epoch"]
         sd = checkpoint["state_dict"]
         global_step = checkpoint.get("step", None)
-        if args.distributed and next(iter(sd.items()))[0].startswith("module"):
+        if not args.distributed and next(iter(sd.items()))[0].startswith("module"):
             sd = {k[len("module.") :]: v for k, v in sd.items()}
         model.load_state_dict(sd)
         logging.info(f"=> resuming checkpoint '{args.resume}' (epoch {start_epoch})")


### PR DESCRIPTION
https://github.com/mlfoundations/open_lm/pull/127
Above PR changed order from model -> load -> distributed to model -> distributed -> load

load_model automatically removes "module" from keys so above change can break load_model
also breaks if distributed and loading weights that do not include module in keys
this pr check if distributed to decide whether to load state_dict to model or model.module