### PR TITLE
Set random seed right before FSDP

### DIFF
--- a/open_lm/main.py
+++ b/open_lm/main.py
@@ -460,7 +460,8 @@ def main(args):
                 fsdp_kwargs["sharding_strategy"] = ShardingStrategy._HYBRID_SHARD_ZERO2
             print("=> FSDP kwargs: ", fsdp_kwargs)
 
-            # init FSDP
+            # Initialize FSDP. Use the same seed across workers to ensure reset_parameters is the same across workers.
+            random_seed(args.seed, rank=0)
             model = FSDP(
                 model,
                 auto_wrap_policy=transformer_auto_wrapper_policy,


### PR DESCRIPTION
FSDP calls reset_parameters individually on each device. Our seed should be the same across devices, but this adds an explicit seed to avoid potential errors (e.g., we implicitly change the seed on rank 0 by calling torch.rand).