### PR TITLE
Allow parsing parameters from a config file

### DIFF
--- a/open_lm/params.py
+++ b/open_lm/params.py
@@ -2,6 +2,7 @@ import argparse
 import ast
 import copy
 import json
+import logging
 import yaml
 
 
@@ -90,12 +91,14 @@ def maybe_load_config(parser, args):
         return None
 
     assert not unknown_args, "No arguments can be passed if --config is provided."
-    print(f"Loading config from: {args.config}")
+    logging.info(f"Loading config from: {args.config}")
     with open(args.config, "r") as f:
-        if args.config.endswith(".yaml"):
+        if args.config.endswith(".yaml") or args.config.endswith(".yml"):
             config = yaml.safe_load(f)
-        else:
+        elif args.config.endswith(".json"):
             config = json.load(f)
+        else:
+            raise ValueError(f"Unknown config format: {args.config}")
 
     default_args = vars(parser.parse_args([]))
     default_arg_keys = default_args.keys()
@@ -566,7 +569,7 @@ def parse_args(args):
     config = maybe_load_config(parser, args)
     if config is not None:
         args = argparse.Namespace(**config)
-        print(f"Loaded config from file: {args=}")
+        logging.info(f"Loaded config from file: {args=}")
     else:
         args = parser.parse_args(args)
 

--- a/open_lm/params.py
+++ b/open_lm/params.py
@@ -1,5 +1,8 @@
 import argparse
 import ast
+import copy
+import json
+import yaml
 
 
 def get_default_params(model_name):
@@ -59,6 +62,59 @@ def add_model_args(parser):
         default="rotary",
         help="Type of positional embedding to use. This might be overridden by the model config.",
     )
+
+
+def check_replacement_type(replacement, original):
+    """Checks that `replacement`, which is intended to replace `original` is of
+    the right type. The type is correct if it matches exactly or is one of a few
+    cases in which the type can be easily coerced.
+
+    Taken from YACS: https://github.com/rbgirshick/yacs/blob/32d5e4ac300eca6cd3b839097dde39c4017a1070/yacs/config.py#L494
+    """
+    # The types must match (with some exceptions)
+    if type(original) == type(replacement):
+        return True
+
+    # If either of them is None, accept the type.
+    if replacement is None or original is None:
+        return True
+
+    return False
+
+
+def maybe_load_config(parser, args):
+    config_parser = argparse.ArgumentParser()
+    config_parser.add_argument("--config", type=str)
+    args, unknown_args = config_parser.parse_known_args(args)
+    if not args.config:
+        return None
+
+    assert not unknown_args, "No arguments can be passed if --config is provided."
+    print(f"Loading config from: {args.config}")
+    with open(args.config, "r") as f:
+        if args.config.endswith(".yaml"):
+            config = yaml.safe_load(f)
+        else:
+            config = json.load(f)
+
+    default_args = vars(parser.parse_args([]))
+    default_arg_keys = default_args.keys()
+    updated_args = copy.deepcopy(default_args)
+
+    for config_key, config_value in config.items():
+        config_key = config_key.replace("-", "_")
+        if config_key not in default_arg_keys:
+            raise ValueError(f"Unknown config key: {config_key}")
+        default_value = default_args[config_key]
+        is_valid = check_replacement_type(replacement=config_value, original=default_value)
+        if not is_valid:
+            raise ValueError(
+                f"Type mismatch (config: {type(config_value)} vs. argparse: {type(default_value)}) with values "
+                f"(config: {config_value} vs. argparse: {default_value}) for config. key: {config_key}"
+            )
+        updated_args[config_key] = config_value
+
+    return updated_args
 
 
 def parse_args(args):
@@ -507,7 +563,12 @@ def parse_args(args):
 
     add_model_args(parser)
 
-    args = parser.parse_args(args)
+    config = maybe_load_config(parser, args)
+    if config is not None:
+        args = argparse.Namespace(**config)
+        print(f"Loaded config from file: {args=}")
+    else:
+        args = parser.parse_args(args)
 
     # If some params are not passed, we use the default values based on model name.
     default_params = get_default_params(args.model)

--- a/tests/test_param_parsing.py
+++ b/tests/test_param_parsing.py
@@ -1,0 +1,81 @@
+import json
+import tempfile
+import pytest
+import yaml
+from contextlib import contextmanager
+
+from open_lm.main import main
+from open_lm.params import parse_args
+
+
+@contextmanager
+def create_config(config_dict, file_type="json"):
+    assert file_type in ("json", "yaml")
+    with tempfile.NamedTemporaryFile(mode="w", suffix="." + file_type) as f:
+        if file_type == "json":
+            json.dump(config_dict, f)
+        elif file_type == "yaml":
+            yaml.safe_dump(config_dict, f)
+        f.seek(0)
+        yield f
+
+
+def get_cmdline_config1():
+    samples = 1000
+    batch_size = 2
+    # fmt: off
+    cmdline = [
+        "--train-num-samples", str(samples),
+        "--batch-size", str(batch_size),
+        "--dataset-type", "synthetic",
+        "--model", "open_lm_test_tiny",
+        "--epochs", "1",
+    ]
+    config_dict = {
+        "train-num-samples": samples,
+        "batch-size": batch_size,
+        "dataset-type": "synthetic",
+        "model": "open_lm_test_tiny",
+        "epochs": 1,
+    }
+    # fmt: on
+    return cmdline, config_dict
+
+
+@pytest.mark.parametrize("filetype", ["json", "yaml"])
+def test_config_params1(filetype):
+    cmdline, config_dict = get_cmdline_config1()
+    cmdline_args = parse_args(cmdline)
+    with create_config(config_dict, filetype) as f:
+        config_args = parse_args(["--config", f.name])
+    assert vars(cmdline_args) == vars(config_args), "Config and command line match failed"
+
+
+@pytest.mark.parametrize("filetype", ["json", "yaml"])
+def test_wrong_type_throws(filetype):
+    config_dict = {"train-num-samples": "100"}
+    with create_config(config_dict, filetype) as f:
+        try:
+            parse_args(["--config", f.name])
+        except ValueError as e:
+            assert "Type mismatch" in str(e)
+
+
+@pytest.mark.parametrize("filetype", ["json", "yaml"])
+def test_extra_config_key_throws(filetype):
+    config_dict = {"this-key-should-not-exist": "100"}
+    with create_config(config_dict, filetype) as f:
+        try:
+            parse_args(["--config", f.name])
+        except ValueError as e:
+            assert "Unknown config" in str(e)
+
+
+@pytest.mark.parametrize("filetype", ["json", "yaml"])
+def test_extra_arg_after_config_throws(filetype):
+    config_dict = {"this-key-should-not-exist": "100"}
+    with create_config(config_dict, filetype) as f:
+        try:
+            parse_args(["--config", f.name, "--train-data", "foo"])
+        except AssertionError as e:
+            assert "--config is provided" in str(e)


### PR DESCRIPTION
This allows us to load parameters from a json or yaml file. If a config is passed via file, then no other arguments are allowed, to avoid confusion due to commandline overrides. Added a few tests that check for equality between config and command line args.