### PR TITLE
Fix training tokens test.

### DIFF
--- a/tests/test_training_tokens.py
+++ b/tests/test_training_tokens.py
@@ -5,6 +5,7 @@ from open_lm.file_utils import get_string_for_epoch
 from open_lm.train import train_one_epoch
 from tests.shared import create_train_fixtures
 from tests.utils import download_dl_test_data
+from torch.cuda.amp import GradScaler
 
 SOURCE_MANIFEST = ["tests/assets/source_3/manifest.jsonl"]
 
@@ -40,6 +41,7 @@ def test_token_count(test_case):
     args.dataset_manifest = SOURCE_MANIFEST
     args.epochs = desired_epochs
     args.train_num_samples = desired_sequences_per_epoch
+    args.scaler = None if args.precision != "amp" else GradScaler()
 
     total_samples = desired_sequences_per_epoch * desired_epochs
     total_steps = total_samples // (args.global_batch_size)


### PR DESCRIPTION
This PR fixes one of the GPU tests, that broke due to a merge commit which handled `create_train_fixtures` somewhat differently.