### PR TITLE
Fix checkpoint loading and resume for fsdp

### DIFF
--- a/open_lm/main.py
+++ b/open_lm/main.py
@@ -109,7 +109,9 @@ def load_model(args, model):
         global_step = checkpoint.get("step", None)
         if next(iter(sd.items()))[0].startswith("module"):
             sd = {k[len("module.") :]: v for k, v in sd.items()}
-        if args.distributed:
+        if args.fsdp:
+            model.load_state_dict(sd)
+        elif args.distributed:
             model.module.load_state_dict(sd)
         else:
             model.load_state_dict(sd)

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ REQUIREMENTS = _read_reqs("requirements.txt")
 
 setuptools.setup(
     name="open_lm",
-    version="0.0.24",
+    version="0.0.25",
     author=[
         "Suchin Gururangan*",
         "Mitchell Wortsman*",


### PR DESCRIPTION
This partially reverts #138. If we use FSDP, we should call load_model directly, instead of model.module.load_model. I tested training and resuming a model using main.py and it works with this commit.

Note that the tests in https://github.com/mlfoundations/open_lm/pull/148 pass despite this bug because of another bug that @kernelmachine discovered incidentally: Our tests are not properly using distributed functionality, because https://github.com/mlfoundations/open_lm/blob/6570b81d60a34ebe902d2b5a0fca04be98108f8c/open_lm/distributed.py#L20-L25 only checks if world_size > 1 (instead of >= 1). This will be tracked in a follow up issue.