### PR TITLE
Fix checkpoint loading and checkpoint tests

### DIFF
--- a/open_lm/distributed.py
+++ b/open_lm/distributed.py
@@ -57,7 +57,7 @@ def init_distributed_device(args):
     args.world_size = 1
     args.rank = 0  # global rank
     args.local_rank = 0
-    # For testing, allow forcing distrubted mode to test distributed code path even on one gpu.
+    # For testing, allow forcing distributed mode to test distributed code path even on one gpu.
     if is_using_distributed() or args.force_distributed:
         if "SLURM_PROCID" in os.environ:
             # DDP via SLURM

--- a/open_lm/distributed.py
+++ b/open_lm/distributed.py
@@ -57,7 +57,8 @@ def init_distributed_device(args):
     args.world_size = 1
     args.rank = 0  # global rank
     args.local_rank = 0
-    if is_using_distributed():
+    # For testing, allow forcing distrubted mode to test distributed code path even on one gpu.
+    if is_using_distributed() or args.force_distributed:
         if "SLURM_PROCID" in os.environ:
             # DDP via SLURM
             args.local_rank, args.rank, args.world_size = world_info_from_env()

--- a/open_lm/main.py
+++ b/open_lm/main.py
@@ -109,7 +109,9 @@ def load_model(args, model):
         global_step = checkpoint.get("step", None)
         if next(iter(sd.items()))[0].startswith("module"):
             sd = {k[len("module.") :]: v for k, v in sd.items()}
-        if args.distributed:
+        if args.fsdp:
+            model.load_state_dict(sd)
+        elif args.distributed:
             model.module.load_state_dict(sd)
         else:
             model.load_state_dict(sd)

--- a/open_lm/main.py
+++ b/open_lm/main.py
@@ -81,7 +81,7 @@ def natural_key(string_):
 def get_latest_checkpoint(path: str):
     is_s3 = path.startswith("s3")
     fs, root_path = fsspec.core.url_to_fs(path)
-    checkpoints = fs.glob(os.path.join(root_path, "**/epoch_*.pt"))
+    checkpoints = fs.glob(os.path.join(root_path, "epoch_*.pt"))
     if checkpoints:
         checkpoints = sorted(checkpoints, key=natural_key)
         return f"s3://{checkpoints[-1]}" if is_s3 else checkpoints[-1]
@@ -261,6 +261,13 @@ def check_args(args):
         )
 
 
+def cleanup(sync_process, distributed=False):
+    if sync_process:
+        terminate_sync_process(sync_process)
+    if distributed and torch.distributed.is_initialized():
+        torch.distributed.destroy_process_group()
+
+
 def main(args):
     args = parse_args(args)
 
@@ -352,6 +359,10 @@ def main(args):
         resume_from = None
         checkpoint_path = args.checkpoint_path
 
+        # If using remote_sync, need to check the remote instead of the local checkpoints folder.
+        if args.remote_sync is not None:
+            checkpoint_path = os.path.join(args.remote_sync, args.name, "checkpoints")
+
         if is_master(args):
             # Checking for existing checkpoint via master rank only. It is possible for
             # different rank processes to see different files if a shared file-system is under
@@ -399,8 +410,11 @@ def main(args):
         )
         remote_sync_process.start()
 
-        # make sure that if open_lm throws the remote process is still killed to prevent hanging
-        atexit.register(terminate_sync_process, p=remote_sync_process)
+    # Handle cleanup even if open_lm crashes.
+    # TODO: For cases where main() is called as a functio, we need to call cleanup() manually.
+    # Right now, we do this manually in every case where main returns, but we should put main() in a wrapper and call
+    # cleanup() outside it, ideally.
+    atexit.register(cleanup, sync_process=remote_sync_process, distributed=args.distributed)
 
     if args.precision == "fp16":
         logging.warning(
@@ -661,6 +675,11 @@ def main(args):
         logging.debug("Finished loading wandb.")
 
     if not requires_training:
+        if not args.resume:
+            logging.info("No training required, exiting.")
+            cleanup(remote_sync_process, args.distributed)
+            return
+        logging.info("No training required, evaluating instead.")
         checkpoint_root = os.path.dirname(args.resume)
 
         metrics = evaluate_loop(model, data["val_list"], start_epoch, args, writer)
@@ -669,6 +688,7 @@ def main(args):
             with fsspec.open(os.path.join(checkpoint_root, "results.jsonl"), "a") as f:
                 f.write(f"{json.dumps(metrics)}\n")
 
+        cleanup(remote_sync_process, args.distributed)
         return
 
     loss = torch.nn.CrossEntropyLoss()
@@ -795,6 +815,7 @@ def main(args):
             logging.info("Final remote sync successful.")
         else:
             logging.info("Final remote sync failed.")
+    cleanup(remote_sync_process, args.distributed)
 
 
 def copy_codebase(args):

--- a/open_lm/params.py
+++ b/open_lm/params.py
@@ -611,6 +611,11 @@ def parse_args(args):
         default=False,
         help="If True, initialize the model on CPU instead of on meta device. This can be useful for debugging or for new models which do not support the meta device.",
     )
+    parser.add_argument(
+        "--force-distributed",
+        action="store_true",
+        help="Allow forcing distributed mode even when running on one gpu. Mostly useful for testing.",
+    )
 
     add_model_args(parser)
 

--- a/tests/shared.py
+++ b/tests/shared.py
@@ -100,6 +100,7 @@ class MockDataArgs(object):
 def create_train_fixtures(model="open_lm_11m", fsdp=False, **kwargs):
     # Setup data, optimizer, and other basic settings
     args = MockTrainArgs(model, **kwargs)
+    args.fsdp = fsdp
 
     # only want to look at one batch
     args.train_num_samples = args.global_batch_size
@@ -111,7 +112,6 @@ def create_train_fixtures(model="open_lm_11m", fsdp=False, **kwargs):
     # create base models
     random_seed()
     if fsdp:
-        init_distributed_device(args)
         model = create_model(args)
         model = FSDP(model)
     else:

--- a/tests/test_grad_accum.py
+++ b/tests/test_grad_accum.py
@@ -50,6 +50,8 @@ def _grad_acc_helper_single(test_fsdp, accs=[2, 1], threshold=1e-7):
         if test_fsdp:
             args.fsdp = True
             args.fsdp_amp = True
+            # Required to force distributed mode on 1 gpu.
+            args.distributed = True
         fixtures.append((args, model, data, optimizer, scheduler, loss))
 
     model1 = fixtures[0][1]

--- a/tests/test_save_load.py
+++ b/tests/test_save_load.py
@@ -126,6 +126,7 @@ def _save_load_helper_fsdp(rank, world_size, tiny_args):
     torch.distributed.destroy_process_group()
 
 
+@pytest.mark.gpu
 def test_tiny_save_load_fsdp(tiny_args):
     world_size = 1
     mp.spawn(_save_load_helper_fsdp, args=(world_size, tiny_args), nprocs=world_size, join=True)

--- a/tests/test_save_load.py
+++ b/tests/test_save_load.py
@@ -1,13 +1,10 @@
 import pytest
-import argparse
 import torch
 import os
+import shutil
 
 import torch.multiprocessing as mp
 
-from open_lm.utils.transformers.hf_model import OpenLMforCausalLM
-from open_lm.utils.transformers.hf_config import OpenLMConfig
-from open_lm.model import create_params
 from open_lm.train import train_one_epoch
 from open_lm.main import save_checkpoint, load_model
 from open_lm.losses import CrossEntropyLossWithZLoss
@@ -31,12 +28,12 @@ def tiny_args():
             "qk_norm": False,
             "positional_embedding_type": "rotary",
             "ffn_type": "swiglu",
-        }
+        },
     )
     return args
 
 
-def test_tiny_save_load(tiny_args, fsdp=False):
+def tiny_save_load(tiny_args, fsdp=False):
     """
     This test checks that the model can be saved and loaded without changing the parameters.
     """
@@ -55,62 +52,66 @@ def test_tiny_save_load(tiny_args, fsdp=False):
         device="cpu" if not torch.cuda.is_available() else "cuda",
         dataset_type="synthetic",
         save_logs=True,
+        distributed=fsdp or is_using_distributed(),
+        force_distributed=fsdp or is_using_distributed(),
     )
 
-    args, model, data, optimizer, scheduler, loss = create_train_fixtures(
-        tiny_args.model, fsdp=False, **override_params
-    )
-    model = model.to(args.device)
-    args2, model2, data2, optimizer2, scheduler2, loss2 = create_train_fixtures(
-        tiny_args.model, fsdp=False, **override_params
-    )
-    model2 = model2.to(args2.device)
-    os.makedirs(args.checkpoint_path, exist_ok=True)
+    try:
+        args, model, data, optimizer, scheduler, loss = create_train_fixtures(
+            tiny_args.model, fsdp=fsdp, **override_params
+        )
+        model = model.to(args.device)
+        args2, model2, data2, optimizer2, scheduler2, loss2 = create_train_fixtures(
+            tiny_args.model, fsdp=fsdp, **override_params
+        )
+        model2 = model2.to(args2.device)
+        os.makedirs(args.checkpoint_path, exist_ok=True)
 
-    # print("Training tiny model")
-    train_one_epoch(
-        model,
-        data,
-        CrossEntropyLossWithZLoss(),
-        epoch=epoch,
-        step=global_step,
-        optimizer=optimizer,
-        scaler=scaler,
-        scheduler=scheduler,
-        total_steps=args.train_num_samples // args.global_batch_size,
-        args=args,
-    )
-    epoch += 1
-    threshold = 1e-6
-    # Checking that tiny models diverged after traning.
-    allclose = True
-    for (n1, p1), (n2, p2) in zip(model.named_parameters(), model2.named_parameters()):
-        allclose = allclose and torch.allclose(p1, p2, atol=threshold)
-    assert not allclose
+        # print("Training tiny model")
+        train_one_epoch(
+            model,
+            data,
+            CrossEntropyLossWithZLoss(),
+            epoch=epoch,
+            step=global_step,
+            optimizer=optimizer,
+            scaler=scaler,
+            scheduler=scheduler,
+            total_steps=args.train_num_samples // args.global_batch_size,
+            args=args,
+        )
+        epoch += 1
+        threshold = 1e-6
+        # Checking that tiny models diverged after traning.
+        allclose = True
+        for (n1, p1), (n2, p2) in zip(model.named_parameters(), model2.named_parameters()):
+            allclose = allclose and torch.allclose(p1, p2, atol=threshold)
+        assert not allclose
 
-    args.distributed = is_using_distributed()
-    # print("Saving tiny model")
-    # Saving checkpoints.
-    save_checkpoint(
-        args,
-        model,
-        optimizer,
-        scaler,
-        epoch,
-        evaluation_metrics,
-        step=global_step,
-        is_final_checkpoint=done_training,
-        next_shard_per_source=None,
-        samples_seen=None,
-    )
+        print("Saving tiny model")
+        # Saving checkpoints.
+        save_checkpoint(
+            args,
+            model,
+            optimizer,
+            scaler,
+            epoch,
+            evaluation_metrics,
+            step=global_step,
+            is_final_checkpoint=done_training,
+            next_shard_per_source=None,
+            samples_seen=None,
+        )
 
-    # Loading saved tiny model
-    args.resume = "./tests/assets/checkpoints/tiny_model/epoch_1.pt"
-    load_model(args, model2)
+        # Loading saved tiny model
+        args.resume = f"{override_params['checkpoint_path']}/epoch_1.pt"
+        load_model(args, model2)
 
-    # Checking that loaded tiny model is the same as the original tiny model
-    for (n1, p1), (n2, p2) in zip(model.named_parameters(), model2.named_parameters()):
-        assert torch.allclose(p1, p2, atol=threshold)
+        # Checking that loaded tiny model is the same as the original tiny model
+        for (n1, p1), (n2, p2) in zip(model.named_parameters(), model2.named_parameters()):
+            assert torch.allclose(p1, p2, atol=threshold)
+    finally:
+        shutil.rmtree(override_params["checkpoint_path"], ignore_errors=True)
 
 
 def _save_load_helper_fsdp(rank, world_size, tiny_args):
@@ -121,13 +122,17 @@ def _save_load_helper_fsdp(rank, world_size, tiny_args):
         rank=rank,
         world_size=world_size,
     )
-    test_tiny_save_load(tiny_args, fsdp=True)
+    tiny_save_load(tiny_args, fsdp=True)
     torch.distributed.destroy_process_group()
 
 
 def test_tiny_save_load_fsdp(tiny_args):
     world_size = 1
     mp.spawn(_save_load_helper_fsdp, args=(world_size, tiny_args), nprocs=world_size, join=True)
+
+
+def test_tiny_save_load(tiny_args):
+    tiny_save_load(tiny_args, fsdp=False)
 
 
 if __name__ == "__main__":

--- a/tests/test_save_load_from_main.py
+++ b/tests/test_save_load_from_main.py
@@ -55,6 +55,7 @@ def test_tiny_save_load_no_distributed():
     tiny_save_load(fsdp=False, distributed=False)
 
 
+@pytest.mark.gpu
 @pytest.mark.parametrize("fsdp", [False, True])
 def test_tiny_save_load_dist_fsdp(fsdp):
     mp.spawn(_save_load_helper_dist, args=(fsdp,), nprocs=1, join=True)

--- a/tests/test_save_load_from_main.py
+++ b/tests/test_save_load_from_main.py
@@ -1,0 +1,68 @@
+import pytest
+import os
+import shutil
+
+import torch.multiprocessing as mp
+
+from open_lm.main import main
+
+
+def tiny_save_load(fsdp=False, distributed=False):
+    """
+    This test checks that the model can be saved and loaded without changing the parameters.
+    """
+    name = "test_tiny_save_load"
+    # fmt: off
+    logdir = "tests/assets/"
+    args = [
+        "--train-num-samples", 64 * 16,  # seq_len is 16 for open_lm_test_tiny
+        "--global-batch-size", 4,
+        "--name", name,
+        "--model", "open_lm_test_tiny",
+        "--dataset-type", "synthetic",
+        "--logs", logdir,
+    ]
+    args = [str(x) for x in args]
+    # fmt: on
+
+    if fsdp:
+        args += ["--fsdp", "--fsdp-amp", "--precision", "amp_bf16"]
+        assert distributed
+
+    if distributed:
+        args += ["--force-distributed"]
+        os.environ["RANK"] = "0"
+        os.environ["WORLD_SIZE"] = "1"
+        os.environ["MASTER_ADDR"] = "127.0.0.1"
+        os.environ["MASTER_PORT"] = "12301"
+
+    try:
+        # Train for one epoch, load the model, then train for another epoch.
+        from torch.distributed.distributed_c10d import GroupMember, _world
+        main(args + ["--epochs", "1"])
+
+        import subprocess
+        subprocess.run(["ls", "--recursive", logdir])
+        print(f"Abspath: {os.path.abspath(logdir)=}")
+        # Loading saved tiny model
+        resume_args = args + ["--resume", "latest", "--epochs", "2"]
+        main(resume_args)
+    finally:
+        shutil.rmtree(f"{logdir}{name}", ignore_errors=True)
+
+
+def _save_load_helper_dist(rank, fsdp):
+    tiny_save_load(fsdp=fsdp, distributed=True)
+
+
+def test_tiny_save_load_no_distributed():
+    tiny_save_load(fsdp=False, distributed=False)
+
+
+@pytest.mark.parametrize("fsdp", [False, True])
+def test_tiny_save_load_dist_fsdp(fsdp):
+    mp.spawn(_save_load_helper_dist, args=(fsdp,), nprocs=1, join=True)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/tests/test_save_load_from_main.py
+++ b/tests/test_save_load_from_main.py
@@ -38,12 +38,8 @@ def tiny_save_load(fsdp=False, distributed=False):
 
     try:
         # Train for one epoch, load the model, then train for another epoch.
-        from torch.distributed.distributed_c10d import GroupMember, _world
         main(args + ["--epochs", "1"])
 
-        import subprocess
-        subprocess.run(["ls", "--recursive", logdir])
-        print(f"Abspath: {os.path.abspath(logdir)=}")
         # Loading saved tiny model
         resume_args = args + ["--resume", "latest", "--epochs", "2"]
         main(resume_args)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -222,6 +222,7 @@ def run_model(open_lm, tokenizer, args, wiki_page=None, start_index=None):
         **generate_args,
     )
     output = tokenizer.decode(output[0].cpu().numpy())
+    torch.distributed.destroy_process_group()
     return output
 
 


### PR DESCRIPTION
This addresses a few issues with our checkpoint save/load tests, and with checkpoint loading itself:

1. Adds a new test that calls main() to test checkpoint saving and loading, ensuring that our full main() pipeline works correctly.
2. Adds a `--force-distributed` flag that allows us to test distributed code paths on a single gpu. Previously, all our tests were running with args.distributed=False, even when args.fsdp=True.
3. Reverts a bug introduced by #153, which meant we did not automatically resume the latest checkpoint when using s3.
4. Fixes a bug in `--resume latest` which led to checkpoints being ignored when resuming in the case of local checkpoints without remote-sync.

Closes #170 