### PR TITLE
fix: add contiguous to xformers_attn

### DIFF
--- a/open_lm/attention.py
+++ b/open_lm/attention.py
@@ -130,9 +130,10 @@ def get_attn_func(
     elif attn_name == "xformers_attn":
         return xformers_attn
     elif attn_name == "xformers_attn_variable_length":
-        # Upon changing the input sequence length, xformers changes the stride
-        # dimension of the output tensor. This makes future calls to .view()
-        # fail. One thus needs to call .contiguous() on the output tensor.
+        # Upon changing the input sequence length, xformers attention changes
+        # the stride dimension of the output tensor. This makes future calls to
+        # .view() that collapses last two dimensions fail. One thus needs to
+        # call .contiguous() on the output tensor. [#188]
         return lambda *args, **kwargs: xformers_attn(*args, **kwargs).contiguous()
     elif attn_name == "torch_attn":
         return torch_attn

--- a/open_lm/attention.py
+++ b/open_lm/attention.py
@@ -125,7 +125,9 @@ def get_attn_func(
     attn_seq_scalar=None,
     alpha=None,
 ):
-    if attn_name == "xformers_attn":
+    if attn_name == "auto":
+        return xformers_attn if torch.cuda.is_available() else torch_attn
+    elif attn_name == "xformers_attn":
         return xformers_attn
     elif attn_name == "xformers_attn_with_variable_length_support":
         return lambda *args, **kwargs: xformers_attn(*args, **kwargs).contiguous()

--- a/open_lm/attention.py
+++ b/open_lm/attention.py
@@ -129,7 +129,10 @@ def get_attn_func(
         return xformers_attn if torch.cuda.is_available() else torch_attn
     elif attn_name == "xformers_attn":
         return xformers_attn
-    elif attn_name == "xformers_attn_with_variable_length_support":
+    elif attn_name == "xformers_attn_variable_length":
+        # Upon changing the input sequence length, xformers changes the stride
+        # dimension of the output tensor. This makes future calls to .view()
+        # fail. One thus needs to call .contiguous() on the output tensor.
         return lambda *args, **kwargs: xformers_attn(*args, **kwargs).contiguous()
     elif attn_name == "torch_attn":
         return torch_attn

--- a/open_lm/attention.py
+++ b/open_lm/attention.py
@@ -34,7 +34,7 @@ def xformers_attn(queries, keys, values, is_causal):
         batch, q_seq_len, heads, _ = queries.shape
         k_seq_len = keys.shape[1]
         mask = get_rectangular_mask((batch, heads), q_seq_len, k_seq_len, queries.device, queries.dtype)
-    return xops.memory_efficient_attention(queries, keys, values, attn_bias=mask)
+    return xops.memory_efficient_attention(queries, keys, values, attn_bias=mask).contiguous()
 
 
 def torch_attn(queries, keys, values, is_causal):

--- a/open_lm/attention.py
+++ b/open_lm/attention.py
@@ -34,7 +34,7 @@ def xformers_attn(queries, keys, values, is_causal):
         batch, q_seq_len, heads, _ = queries.shape
         k_seq_len = keys.shape[1]
         mask = get_rectangular_mask((batch, heads), q_seq_len, k_seq_len, queries.device, queries.dtype)
-    return xops.memory_efficient_attention(queries, keys, values, attn_bias=mask).contiguous()
+    return xops.memory_efficient_attention(queries, keys, values, attn_bias=mask)
 
 
 def torch_attn(queries, keys, values, is_causal):
@@ -127,6 +127,8 @@ def get_attn_func(
 ):
     if attn_name == "xformers_attn":
         return xformers_attn
+    elif attn_name == "xformers_attn_with_variable_length_support":
+        return lambda *args, **kwargs: xformers_attn(*args, **kwargs).contiguous()
     elif attn_name == "torch_attn":
         return torch_attn
     elif attn_name == "custom_attn":

--- a/open_lm/model.py
+++ b/open_lm/model.py
@@ -120,7 +120,7 @@ class CustomAttn(nn.Module):
         self.in_proj = nn.Linear(args.dim, 3 * args.n_heads * self.head_dim, bias=False)
         self.out_proj = nn.Linear(args.n_heads * self.head_dim, args.dim, bias=False)
         self.pos_embed = get_pos_embed(args)
-        self.attn_fn = xformers_attn if torch.cuda.is_available() else torch_attn
+        self.attn_fn = args.attn_func
         self.apply_qk_norm = args.apply_qk_norm
 
         # initialize norm layers for queries and keys if needed

--- a/open_lm/params.py
+++ b/open_lm/params.py
@@ -105,8 +105,8 @@ def add_model_args(parser):
     parser.add_argument(
         "--attn-name",
         type=str,
-        default="xformers_attn",
-        choices=["xformers_attn", "xformers_attn_with_variable_length_support", "torch_attn", "custom_attn"],
+        default="auto",
+        choices=["auto", "xformers_attn", "xformers_attn_with_variable_length_support", "torch_attn", "custom_attn"],
         help="type of attention to use",
     )
     parser.add_argument(

--- a/open_lm/params.py
+++ b/open_lm/params.py
@@ -106,7 +106,7 @@ def add_model_args(parser):
         "--attn-name",
         type=str,
         default="xformers_attn",
-        choices=["xformers_attn", "torch_attn", "custom_attn"],
+        choices=["xformers_attn", "xformers_attn_with_variable_length_support", "torch_attn", "custom_attn"],
         help="type of attention to use",
     )
     parser.add_argument(

--- a/open_lm/params.py
+++ b/open_lm/params.py
@@ -106,7 +106,7 @@ def add_model_args(parser):
         "--attn-name",
         type=str,
         default="auto",
-        choices=["auto", "xformers_attn", "xformers_attn_with_variable_length_support", "torch_attn", "custom_attn"],
+        choices=["auto", "xformers_attn", "xformers_attn_variable_length", "torch_attn", "custom_attn"],
         help="type of attention to use",
     )
     parser.add_argument(


### PR DESCRIPTION
I encountered the following issue: 

ExecutorError: HuggingFace error: view size is not compatible with input tensor's size and stride (at least one dimension spans across two contiguous subspaces). Use .reshape(...) instead. Request: 
Request(model_deployment='open_lm/default-open_lm_1b', model='open_lm/default-open_lm_1b', embedding=False, prompt='Passage: The Little White Bird is a series of short episodes, including both accounts of the narrator\'s day-to-day activities ... inheritance.\nQuestion: What is bigamy?\nAnswer:', temperature=0.0, num_completions=1, top_k_per_token=1, max_tokens=100, stop_sequences=['\n'], 
echo_prompt=False, top_p=1, presence_penalty=0, frequency_penalty=0, random=None, messages=None, multimodal_prompt=None)

and I was able to fix it by adding `.contiguous()` to the output of xformer operation. 

I'm using xformers == 0.0.22.post7, and xformers==0.0.21 does not have such issue