### PR TITLE
More accurate precounting of checkpoints.

### DIFF
--- a/open_lm/file_utils.py
+++ b/open_lm/file_utils.py
@@ -289,7 +289,7 @@ def log_num_checkpoints(total_steps, args):
 
         # we then find the batches that each worker will produce
         num_batches_per_global_worker_per_source = [
-            np.array([n // args.global_batch_size for n in nsamples])
+            np.array([n // args.per_gpu_batch_size for n in nsamples])
             for nsamples in num_samples_per_global_worker_per_source
         ]
         num_batches_per_global_worker = sum(num_batches_per_global_worker_per_source)


### PR DESCRIPTION
This PR makes some edits to the `log_num_checkpoints` function, so that the precounting of steps done during training is more accurate.

This partially addresses #189, where imbalanced shards would lead to misleading precounting of steps.