### PR TITLE
Don't double count jsonl.gz

### DIFF
--- a/open_lm/datapreprocess/ray/tokenize_shuffle.py
+++ b/open_lm/datapreprocess/ray/tokenize_shuffle.py
@@ -514,7 +514,6 @@ def main(args):
         input_paths += glob_files(inp_folder, suffix=".json")
         input_paths += glob_files(inp_folder, suffix=".jsonl")
         input_paths += glob_files(inp_folder, suffix=".zst")
-        input_paths += glob_files(inp_folder, suffix=".jsonl.gz")
         input_paths += glob_files(inp_folder, suffix=".tar")
         input_paths += glob_files(inp_folder, suffix=".gz")
     rng = random.Random(args.seed)

--- a/open_lm/datapreprocess/ray/tokenize_shuffle.py
+++ b/open_lm/datapreprocess/ray/tokenize_shuffle.py
@@ -516,6 +516,7 @@ def main(args):
         input_paths += glob_files(inp_folder, suffix=".zst")
         input_paths += glob_files(inp_folder, suffix=".tar")
         input_paths += glob_files(inp_folder, suffix=".gz")
+    input_paths = sorted(set(input_paths))
     rng = random.Random(args.seed)
     rng.shuffle(input_paths)  # shuffle before selecting subsets
     if args.subset is not None:


### PR DESCRIPTION
Tokenize-shuffle globs jsonl.gz and .gz separately, so we end up seeing some files more than once. This fixes that.