### PR TITLE
Enable multiple passes over the dataset.

### DIFF
--- a/open_lm/file_utils.py
+++ b/open_lm/file_utils.py
@@ -251,6 +251,7 @@ def log_num_checkpoints(total_steps, args):
             args.train_data_mix_weights,
             args.workers,
             args.world_size,
+            multi_epoch=args.multiple_data_passes,
             shard_shuffle_seed=args.shard_shuffle_seed,
         )
         steps_epoch = sum(

--- a/open_lm/file_utils.py
+++ b/open_lm/file_utils.py
@@ -321,13 +321,13 @@ def _multi_epoch_string(
         [starting_shard_per_source[i] // total_shards_per_source[i] == pass_idx for i in range(num_sources)]
     ), "Passes across sources are not synced."
 
-    starting_shard_per_source_single = [
-        starting_shard_per_source[i] % total_shards_per_source[i] for i in range(num_sources)
-    ]
     retries = 3
 
     while retries > 0:
         try:
+            starting_shard_per_source_single = [
+                starting_shard_per_source[i] % total_shards_per_source[i] for i in range(num_sources)
+            ]
             shard_strings_per_source, num_samples_per_source, next_shard_per_source = _single_epoch_string(
                 num_samples=num_samples,
                 starting_shard_per_source=starting_shard_per_source_single,
@@ -344,7 +344,7 @@ def _multi_epoch_string(
         except IndexError as e:
             # In this case, we have run out of shards for this pass, so we will start a new pass of our dataset.
             pass_idx += 1
-            starting_shard_per_source_single = [pass_idx * total_shards_per_source[i] for i in range(num_sources)]
+            starting_shard_per_source = [pass_idx * total_shards_per_source[i] for i in range(num_sources)]
             retries -= 1
 
     raise ValueError(

--- a/open_lm/main.py
+++ b/open_lm/main.py
@@ -712,6 +712,7 @@ def main(args):
                 args.train_data_mix_weights,
                 args.workers,
                 args.world_size,
+                multi_epoch=args.multiple_data_passes,
                 shard_shuffle_seed=args.shard_shuffle_seed,
             )
 

--- a/open_lm/params.py
+++ b/open_lm/params.py
@@ -723,6 +723,11 @@ def parse_args(args):
         action="store_true",
         help="Allow forcing distributed mode even when running on one gpu. Mostly useful for testing.",
     )
+    parser.add_argument(
+        "--multiple-data-passes",
+        action="store_true",
+        help="If set, allow model to do multiple data passes over our dataset, in order to reach the desired number of tokens."
+    )
 
     add_model_args(parser)
 

--- a/open_lm/params.py
+++ b/open_lm/params.py
@@ -726,7 +726,7 @@ def parse_args(args):
     parser.add_argument(
         "--multiple-data-passes",
         action="store_true",
-        help="If set, allow model to do multiple data passes over our dataset, in order to reach the desired number of tokens."
+        help="If set, allow model to do multiple data passes over our dataset, in order to reach the desired number of tokens.",
     )
 
     add_model_args(parser)


### PR DESCRIPTION
This PR adds an extra flag `--multiple-data-passes` which allows for multiple passes over the dataset.
The code is set up so that the total number of tokens that will be seen across all passes of the dataset will still be `epochs * train_num_samples`, only in this case instead of erroring when data runs out, we move on to the next pass of the dataset (shuffling the shards as well, so that we see them in different order in each pass).

This is a WIP, since a few more test cases need to be added.