### PR TITLE
remove double counting for jsonl.gzip files

### DIFF
--- a/open_lm/datapreprocess/ray/tokenize_shuffle.py
+++ b/open_lm/datapreprocess/ray/tokenize_shuffle.py
@@ -589,7 +589,6 @@ def main(args):
         input_paths += glob_files(inp_folder, suffix=".json")
         input_paths += glob_files(inp_folder, suffix=".jsonl")
         input_paths += glob_files(inp_folder, suffix=".zst")
-        input_paths += glob_files(inp_folder, suffix=".jsonl.gz")
         input_paths += glob_files(inp_folder, suffix=".tar")
         input_paths += glob_files(inp_folder, suffix=".gz")
     rng = random.Random(args.seed)


### PR DESCRIPTION
currently our suffix list will double count files that end in "jsonl.gz", duplicating tokens