### PR TITLE
Adding support for FP8 training

### DIFF
--- a/open_lm/norms.py
+++ b/open_lm/norms.py
@@ -8,6 +8,16 @@ import torch.nn as nn
 import torch.nn.functional as F
 from torch.nn.parameter import Parameter
 
+# Adding flag if using TE FP8
+using_te = False
+try:
+    import transformer_engine.pytorch as te
+    from transformer_engine.common import recipe
+    fp8_format = recipe.Format.HYBRID
+    fp8_recipe = recipe.DelayedScaling(fp8_format=fp8_format, amax_history_len=32, amax_compute_algo="max")
+    using_te = True
+except ImportError as ie:
+    using_te = False
 
 class LayerNorm(nn.Module):
     # NOTE: taken from official pytorch implementation and modified
@@ -55,7 +65,14 @@ class LayerNorm(nn.Module):
                 self.bias.zero_()
 
     def forward(self, input: Tensor) -> Tensor:
-        return F.layer_norm(input, self.normalized_shape, self.weight, self.bias, self.eps)
+        if using_te:
+            layer_norm_module = te.LayerNorm(self.normalized_shape, eps=self.eps, device='cuda', params_dtype=input.dtype)
+            output_tensor = layer_norm_module(input)
+            if self.weight is not None and self.bias is not None:
+                output_tensor = output_tensor * self.weight + self.bias
+            return output_tensor
+        else:
+            return F.layer_norm(input, self.normalized_shape, self.weight, self.bias, self.eps)
 
     def extra_repr(self) -> str:
         return (
@@ -77,13 +94,20 @@ class LPLayerNorm(LayerNorm):
         downcast_weight = _cast_if_autocast_enabled(self.weight) if self.weight is not None else self.weight
         downcast_bias = _cast_if_autocast_enabled(self.bias) if self.bias is not None else self.bias
         with torch.autocast(enabled=False, device_type=module_device.type):
-            return F.layer_norm(
-                downcast_x,
-                self.normalized_shape,
-                downcast_weight,
-                downcast_bias,
-                self.eps,
-            )
+            if using_te:
+                layer_norm_module = te.LayerNorm(self.normalized_shape, eps=self.eps, device='cuda', params_dtype=downcast_x.dtype)
+                output_tensor = layer_norm_module(downcast_x)
+                if downcast_weight is not None and downcast_bias is not None:
+                    output_tensor = output_tensor * downcast_weight + downcast_bias
+                return output_tensor
+            else:
+                return F.layer_norm(
+                    downcast_x,
+                    self.normalized_shape,
+                    downcast_weight,
+                    downcast_bias,
+                    self.eps,
+                )
 
 
 def _cast_if_autocast_enabled(tensor):

--- a/open_lm/params.py
+++ b/open_lm/params.py
@@ -742,6 +742,17 @@ def parse_args(args):
         action="store_true",
         help="If set, allow model to do multiple data passes over our dataset, in order to reach the desired number of tokens.",
     )
+    parser.add_argument(
+        "--use-smp-flash-attention",
+        type=int,
+        default=None,
+        help="Using SMP Flash Attention.",
+    )
+    parser.add_argument(
+        "--sharding-strategy",
+        default=None,
+        help="Sharding Strategy",
+    )
 
     add_model_args(parser)
 


### PR DESCRIPTION
- Changes made to `train.py`, `model.py`, and `norms.py` to check if Transformer Engine can be imported for P5 instances or H100s and use FP8 for Linear and LayerNorm layers. 
- Minor modifications to `main.py` for FP8 support