### PR TITLE
added InContextLearningCodeEvalAccuracy to evaluation metrics

### DIFF
--- a/open_lm/utils/llm_foundry_wrapper.py
+++ b/open_lm/utils/llm_foundry_wrapper.py
@@ -11,6 +11,7 @@ from composer.metrics.nlp import (
     InContextLearningMCExpectedCalibrationError,
     InContextLearningMultipleChoiceAccuracy,
     InContextLearningQAAccuracy,
+    InContextLearningCodeEvalAccuracy,
     LanguageCrossEntropy,
     LanguagePerplexity,
 )
@@ -35,6 +36,7 @@ EVAL_METRICS = [
     InContextLearningQAAccuracy(),
     InContextLearningLMExpectedCalibrationError(),
     InContextLearningMCExpectedCalibrationError(),
+    InContextLearningCodeEvalAccuracy()
 ]
 
 

--- a/open_lm/utils/llm_foundry_wrapper.py
+++ b/open_lm/utils/llm_foundry_wrapper.py
@@ -36,7 +36,7 @@ EVAL_METRICS = [
     InContextLearningQAAccuracy(),
     InContextLearningLMExpectedCalibrationError(),
     InContextLearningMCExpectedCalibrationError(),
-    InContextLearningCodeEvalAccuracy()
+    InContextLearningCodeEvalAccuracy(),
 ]
 
 


### PR DESCRIPTION
human_eval tasks have a corresponding metric type, InContextLearningCodeEvalAccuracy, which was not included in the llm foundry wrapper. As a result, human_eval metrics were not being written to the evaluation output file.