### PR TITLE
Add the ability to preset world size.

### DIFF
--- a/open_lm/distributed.py
+++ b/open_lm/distributed.py
@@ -62,9 +62,10 @@ def init_distributed_device(args):
         if "SLURM_PROCID" in os.environ:
             # DDP via SLURM
             args.local_rank, args.rank, env_world_size = world_info_from_env()
-            if args.world_size is None:
+            if args.preset_world_size is None:
                 args.world_size = env_world_size
             else:
+                args.world_size = args.preset_world_size
                 if args.rank >= args.world_size:
                     logging.info(f"Rank {args.rank} not needed with world size {args.world_size}. Exiting.")
                     exit(0)
@@ -82,7 +83,7 @@ def init_distributed_device(args):
         else:
             # DDP via torchrun, torch.distributed.launch
             # Note that this currently assumes that the world size is all gpus in a node.
-            assert args.world_size is None, "Setting --world_size with torchrun is not currently supported."
+            assert args.preset_world_size is None, "--preset_world_size with torchrun is not currently supported."
             args.local_rank, _, _ = world_info_from_env()
             torch.distributed.init_process_group(backend=args.dist_backend, init_method=args.dist_url)
             args.world_size = torch.distributed.get_world_size()

--- a/open_lm/params.py
+++ b/open_lm/params.py
@@ -741,7 +741,7 @@ def parse_args(args):
         "--preset-world-size",
         type=int,
         default=None,
-        help="Explicitly set the world size. Useful in cases where a different number of gpus per node need to be used."
+        help="Explicitly set the world size. Useful in cases where a different number of gpus per node need to be used.",
     )
     parser.add_argument(
         "--multiple-data-passes",

--- a/open_lm/params.py
+++ b/open_lm/params.py
@@ -738,6 +738,12 @@ def parse_args(args):
         help="Allow forcing distributed mode even when running on one gpu. Mostly useful for testing.",
     )
     parser.add_argument(
+        "--world-size",
+        type=int,
+        default=None,
+        help="Explicitly set the world size. Useful in cases where a different number of gpus per node need to be used."
+    )
+    parser.add_argument(
         "--multiple-data-passes",
         action="store_true",
         help="If set, allow model to do multiple data passes over our dataset, in order to reach the desired number of tokens.",

--- a/open_lm/params.py
+++ b/open_lm/params.py
@@ -738,7 +738,7 @@ def parse_args(args):
         help="Allow forcing distributed mode even when running on one gpu. Mostly useful for testing.",
     )
     parser.add_argument(
-        "--world-size",
+        "--preset-world-size",
         type=int,
         default=None,
         help="Explicitly set the world size. Useful in cases where a different number of gpus per node need to be used."


### PR DESCRIPTION
This option adds the ability to preset the world size to be used, when working on a SLURM cluster, overriding the world size provided by the environment variables.

This is helpful in cases where a different number of GPUs per node need to be used, to account for clusters with non-standard number of GPUs per node.