### PR TITLE
Add unit test for source mixing + Fix naming within tars.

### DIFF
--- a/open_lm/datapreprocess/ray/tokenize_shuffle.py
+++ b/open_lm/datapreprocess/ray/tokenize_shuffle.py
@@ -234,7 +234,7 @@ class BufferedShardWriter:
                 tokens = [int(x) for x in self.buffer[i]["tokens"]]
                 token_count += len(tokens)
                 json_string = json.dumps(tokens)
-                uid = hashlib.md5(json_string.encode()).hexdigest()
+                uid = f"{tar_index_str}_{i:0{digits}}"
                 sample = {"__key__": uid, "json.gz": json_string}
                 sink.write(sample)
         bio.seek(0)

--- a/tests/assets/test_sample.yaml
+++ b/tests/assets/test_sample.yaml
@@ -1,0 +1,13 @@
+sources:
+  - source: "SOURCE_A"
+    markers: ["source_a"]
+  - source: "SOURCE_B"
+    markers: ["source_b"]
+  - source: "UNKNOWN"
+    markers: []  # No specific markers for UNKNOWN
+
+sampling_frequencies:
+  SOURCE_A: 2.0
+  SOURCE_B: 0.5
+  UNKNOWN: 0
+


### PR DESCRIPTION
This adds a unit test for mixing sources, both with and without sampling.

This also fixes the naming scheme within tars, which could cause issues if two sequences within the same tar contained the same tokens - this would also result in the same name within the tarfile, which breaks WebDataset.