### PR TITLE
main.py: set_grad_checkpointing before DDP or FSDP wrap

### DIFF
--- a/open_lm/main.py
+++ b/open_lm/main.py
@@ -439,6 +439,9 @@ def main(args):
 
     random_seed(args.seed, args.rank)
 
+    if args.grad_checkpointing:
+        model.set_grad_checkpointing()
+
     if args.distributed:
         if args.fsdp:
             transformer_layer_cls = None
@@ -515,9 +518,6 @@ def main(args):
                 # this doesn't exist in older PyTorch, arg only added if enabled
                 ddp_args["static_graph"] = True
             model = torch.nn.parallel.DistributedDataParallel(model, device_ids=[device], **ddp_args)
-
-    if args.grad_checkpointing:
-        model.set_grad_checkpointing()
 
     if is_master(args):
         logging.info(f"Model (has {sum(p.numel() for p in model.parameters() if p.requires_grad)} parameters):")


### PR DESCRIPTION
DDP + --grad-checkpointing resulted in but works with FSDP

```
AttributeErrorAttributeErrorAttributeError: : 'DistributedDataParallel' object has no attribute 'set_grad_checkpointing
': 'DistributedDataParallel' object has no attribute 'set_grad_checkpointing''DistributedDataParallel' object has no at
tribute 'set_grad_checkpointing'    raise AttributeError(f"'{type(self).__name__}' object has no attribute '{name}'")  
AttributeError: 'DistributedDataParallel' object has no attribute 'set_grad_checkpointing' 
```

I guess FSDP passes along set_grad_checkpointing to the module but not DDP. This works with both configurations