### PR TITLE
Adding averaging of iterates

### DIFF
--- a/open_lm/main.py
+++ b/open_lm/main.py
@@ -32,7 +32,7 @@ from torch.distributed.fsdp.wrap import transformer_auto_wrap_policy
 from open_lm.data import proc_token
 from open_lm.model import Block
 from open_lm.losses import CrossEntropyLossWithZLoss
-
+from open_lm.utils.average_utils import ModelAverager
 try:
     import wandb
 except ImportError:
@@ -50,7 +50,7 @@ from open_lm.data import get_data, get_wds_dataset
 from open_lm.distributed import is_master, init_distributed_device, broadcast_object
 from open_lm.logger import setup_logging
 from open_lm.params import parse_args
-from open_lm.scheduler import cosine_lr
+from open_lm.scheduler import cosine_lr, const_lr
 from open_lm.train import train_one_epoch
 from open_lm.evaluate import evaluate_loop
 from open_lm.file_utils import (
@@ -137,6 +137,19 @@ def load_model(args, model, different_seed=False):
         logging.info(f"=> loaded checkpoint '{args.resume}' (epoch {start_epoch})")
     return start_epoch, global_step, pretrained_seed
 
+def load_avg_models(args, averagers):
+    checkpoint = pt_load(args.resume, map_location="cpu")
+    if "epoch" in checkpoint:
+        # resuming a train checkpoint w/ epoch and optimizer state
+        start_epoch = checkpoint["epoch"]
+        if averagers is not None:
+            for k in averagers.avgs_dict:
+                avg_sd = torch.load(args.resume.replace('epoch', k), map_location='cpu')
+                if next(iter(avg_sd.items()))[0].startswith("module"):
+                    avg_sd = {k[len("module.") :]: v for k, v in avg_sd.items()}
+                averagers.avgs_dict[k].load_state_dict_avg(avg_sd)
+                logging.info(f"=> resuming averager for {k} from checkpoint '{args.resume.replace('epoch', k)} (epoch {start_epoch})")
+    return
 
 def load_optimizer(args, model, optimizer, scaler):
     potential_checkpoint = args.resume.replace("epoch_", "optimizer_")
@@ -181,6 +194,7 @@ def save_checkpoint(
     next_shard_per_source=None,
     samples_seen=None,
     shard_shuffle_seed=None,
+    averagers=None,
 ):
     cpu_state, optim_state = None, None
     if args.logs and args.logs.lower() != "none" and args.fsdp:
@@ -230,6 +244,9 @@ def save_checkpoint(
             "stats_": checkpoint_dict_stats,
         }
 
+        if averagers is not None:
+            for k in averagers.avgs_dict:
+                prefixes[f"{k}_"] = averagers.avgs_dict[k].state_dict_avg()
         if (
             completed_epoch == args.epochs
             or is_final_checkpoint
@@ -437,6 +454,7 @@ def main(args):
             )
         args.val_num_samples //= args.seq_len
 
+    averagers = None
     random_seed(args.seed, args.rank)
 
     if args.grad_checkpointing:
@@ -518,6 +536,10 @@ def main(args):
                 # this doesn't exist in older PyTorch, arg only added if enabled
                 ddp_args["static_graph"] = True
             model = torch.nn.parallel.DistributedDataParallel(model, device_ids=[device], **ddp_args)
+    if args.averagers is not None:
+        averagers = ModelAverager(model, args.averagers)
+    if args.resume is not None and averagers is not None:
+        load_avg_models(args, averagers)
 
     if is_master(args):
         logging.info(f"Model (has {sum(p.numel() for p in model.parameters() if p.requires_grad)} parameters):")
@@ -535,6 +557,7 @@ def main(args):
     shard_shuffle_seed = args.seed
     if args.resume is not None:
         start_epoch, global_step, shard_shuffle_seed = load_model(args, model)
+
     elif args.pretrained is not None:
         print("=> loading from a pre-trained model.")
         args.resume = args.pretrained
@@ -627,6 +650,10 @@ def main(args):
     if args.torchcompile:
         logging.info("Compiling model...")
         model = torch.compile(model)
+        if averagers is not None:
+            logging.info("Compiling averagers...")
+            for k in averagers.avgs_dict:
+                averagers.avgs_dict[k].av_model = torch.compile(averagers.avgs_dict[k].av_model)
 
     # create scheduler if train
     scheduler = None
@@ -636,14 +663,29 @@ def main(args):
         else:
             total_steps = (data["train"].dataloader.num_batches) * args.epochs
 
-        scheduler = cosine_lr(
-            optimizer,
-            args.lr,
-            args.warmup,
-            total_steps,
-            args.lr_cooldown_end,
-            args.force_min_lr,
-        )
+        if args.lr_scheduler == "cosine":
+            scheduler = cosine_lr(
+                optimizer,
+                args.lr,
+                args.warmup,
+                total_steps,
+                args.lr_cooldown_end,
+                args.force_min_lr,
+            )
+        elif args.lr_scheduler == "const":
+            scheduler = const_lr(
+                optimizer,
+                args.lr,
+                args.warmup,
+                # total_steps,
+                # args.lr_cooldown_end,
+                # args.force_min_lr,
+            )
+        else:
+            logging.error(
+                f"Unknown scheduler, {args.lr_scheduler}. Available options are: cosine, const."
+            )
+            exit(1)
 
     # determine if this worker should save logs and checkpoints. only do so if it is rank == 0
     args.save_logs = args.logs and args.logs.lower() != "none" and is_master(args)
@@ -675,8 +717,13 @@ def main(args):
             return
         logging.info("No training required, evaluating instead.")
         checkpoint_root = os.path.dirname(args.resume)
-
+        
+        if averagers is not None:
+            k = next(iter(averagers.avgs_dict.keys()))
+            logging.info(f'=> evaluation avg {k}')
+            model = averagers.avgs_dict[k].av_model
         metrics = evaluate_loop(model, data["val_list"], start_epoch, args, writer)
+        metrics["average"] = k if averagers is not None else 'none'
 
         if is_master(args):
             with fsspec.open(os.path.join(checkpoint_root, "results.jsonl"), "a") as f:
@@ -746,6 +793,7 @@ def main(args):
             model,
             data,
             loss,
+            averagers=averagers,
             epoch=epoch,
             step=global_step,
             optimizer=optimizer,
@@ -797,6 +845,7 @@ def main(args):
             next_shard_per_source=next_shard_per_source if args.dataset_manifest is not None else None,
             samples_seen=samples_seen if args.dataset_manifest is not None else None,
             shard_shuffle_seed=args.shard_shuffle_seed,
+            averagers=averagers,
         )
 
         if done_training:

--- a/open_lm/main.py
+++ b/open_lm/main.py
@@ -687,8 +687,7 @@ def main(args):
                 # args.force_min_lr,
             )
         else:
-            logging.error(f"Unknown scheduler, {args.lr_scheduler}. Available options are: cosine, const.")
-            exit(1)
+            raise ValueError(f"Unknown scheduler, {args.lr_scheduler}. Available options are: cosine, const.")
 
     # determine if this worker should save logs and checkpoints. only do so if it is rank == 0
     args.save_logs = args.logs and args.logs.lower() != "none" and is_master(args)

--- a/open_lm/main.py
+++ b/open_lm/main.py
@@ -251,7 +251,7 @@ def save_checkpoint(
 
         if averagers is not None:
             for k in averagers.avgs_dict:
-                prefixes[f"{k}_"] = averagers.avgs_dict[k].state_dict_avg()
+                prefixes[f"{k}_"] = averagers.avgs_dict[k].get_state_dict_avg()
         if (
             completed_epoch == args.epochs
             or is_final_checkpoint

--- a/open_lm/main.py
+++ b/open_lm/main.py
@@ -32,7 +32,7 @@ from torch.distributed.fsdp.wrap import transformer_auto_wrap_policy
 from open_lm.data import proc_token
 from open_lm.model import Block
 from open_lm.losses import CrossEntropyLossWithZLoss
-from open_lm.utils.average_utils import ModelAverager
+from open_lm.utils.averaging_utils import ModelAverager
 try:
     import wandb
 except ImportError:

--- a/open_lm/params.py
+++ b/open_lm/params.py
@@ -748,7 +748,17 @@ def parse_args(args):
         action="store_true",
         help="If set, allow model to do multiple data passes over our dataset, in order to reach the desired number of tokens.",
     )
-
+    
+    parser.add_argument("--averagers",
+        type=str,
+        default=None,
+        help="Optinoally average checkpoints along the trajectory.",
+    )
+    parser.add_argument("--log-avg-model-training-loss",
+        type=int,
+        default=0,
+        help="Whether to log the average model training loss. if not 0, it will log the average loss over the specified number of steps."
+    )
     add_model_args(parser)
 
     config = maybe_load_config(parser, args)

--- a/open_lm/params.py
+++ b/open_lm/params.py
@@ -237,7 +237,7 @@ def check_args(args):
             if args.remote_sync_protocol != "s3":
                 raise ValueError("Sync protocol not supported when using resume latest.")
 
-    if args.lr_scheduler != "cosine":
+    if args.lr_scheduler != "cosine" or args.lr_scheduler != "const" or args.lr_scheduler != "const-cooldown":
         raise ValueError(
             f"Unknown scheduler, {args.lr_scheduler}. Available options are: cosine, const, const-cooldown."
         )

--- a/open_lm/params.py
+++ b/open_lm/params.py
@@ -237,7 +237,7 @@ def check_args(args):
             if args.remote_sync_protocol != "s3":
                 raise ValueError("Sync protocol not supported when using resume latest.")
 
-    if args.lr_scheduler != "cosine" or args.lr_scheduler != "const" or args.lr_scheduler != "const-cooldown":
+    if args.lr_scheduler not in {"cosine", "const", "const-cooldown"}:
         raise ValueError(
             f"Unknown scheduler, {args.lr_scheduler}. Available options are: cosine, const, const-cooldown."
         )

--- a/open_lm/params.py
+++ b/open_lm/params.py
@@ -748,16 +748,18 @@ def parse_args(args):
         action="store_true",
         help="If set, allow model to do multiple data passes over our dataset, in order to reach the desired number of tokens.",
     )
-    
-    parser.add_argument("--averagers",
+
+    parser.add_argument(
+        "--averagers",
         type=str,
         default=None,
         help="Optinoally average checkpoints along the trajectory.",
     )
-    parser.add_argument("--log-avg-model-training-loss",
+    parser.add_argument(
+        "--log-avg-model-training-loss",
         type=int,
         default=0,
-        help="Whether to log the average model training loss. if not 0, it will log the average loss over the specified number of steps."
+        help="Whether to log the average model training loss. if not 0, it will log the average loss over the specified number of steps.",
     )
     add_model_args(parser)
 

--- a/open_lm/train.py
+++ b/open_lm/train.py
@@ -297,7 +297,7 @@ def train_one_epoch(
                 }
 
                 if averagers is not None and args.log_avg_model_training_loss:
-                    for k in averagers.avgs_dict().keys():
+                    for k in averagers.avgs_dict.keys():
                         if (
                             averagers is not None
                             and args.log_avg_model_training_loss
@@ -321,7 +321,7 @@ def train_one_epoch(
                 # reset all average meters
                 losses_m.reset()
                 if averagers is not None:
-                    for k in averagers.avgs_dict().keys():
+                    for k in averagers.avgs_dict.keys():
                         losses_avg_m[k].reset()
 
                 if math.isnan(losses_m.val):

--- a/open_lm/train.py
+++ b/open_lm/train.py
@@ -138,7 +138,7 @@ def train_one_epoch(
                 with autocast():
                     for key, averager in averagers.avgs_dict.items():
                         with torch.no_grad():
-                            out_avg, _ = averager.av_model(inputs)
+                            out_avg, _, _ = averager.av_model(inputs)
                             # save the loss for the average model for logging
                             total_loss_avg[key] = loss(out_avg.reshape(-1, args.vocab_size), targets.reshape(-1))
         else:
@@ -185,10 +185,11 @@ def train_one_epoch(
                         ):
                             for key, averager in averagers.avgs_dict.items():
                                 with torch.no_grad():
-                                    out_avg, _ = averager.av_model(inputs_ii).item()
+                                    out_avg, _, _ = averager.av_model(inputs_ii)
                                     local_avg_losses[key] = (
-                                        loss(out_avg.reshape(-1, args.vocab_size), targets.reshape(-1))
-                                        / args.accum_freq
+                                        loss(out_avg.reshape(-1, args.vocab_size), targets_ii.reshape(-1))
+                                        * inputs_ii.shape[0]
+                                        / inputs.shape[0]
                                     )
                 if ii == 0:
                     total_lm_loss = local_lm_loss
@@ -296,7 +297,7 @@ def train_one_epoch(
                 }
 
                 if averagers is not None and args.log_avg_model_training_loss:
-                    for k in averagers.avgs_dict:
+                    for k in averagers.avgs_dict().keys():
                         if (
                             averagers is not None
                             and args.log_avg_model_training_loss
@@ -320,8 +321,8 @@ def train_one_epoch(
                 # reset all average meters
                 losses_m.reset()
                 if averagers is not None:
-                    for k in averagers.avgs_dict():
-                        losses_avg_m.reset()
+                    for k in averagers.avgs_dict().keys():
+                        losses_avg_m[k].reset()
 
                 if math.isnan(losses_m.val):
                     # case where loss goes to nan, we see this sometimes with bad nodes.

--- a/open_lm/utils/averaging_utils.py
+++ b/open_lm/utils/averaging_utils.py
@@ -1,0 +1,129 @@
+import numpy as np
+import torch
+import logging
+from copy import deepcopy
+
+def unwrap_model(model):
+    return model.module if hasattr(model, 'module') else model
+
+
+
+class ModelAverager(object):
+    def __init__(self, model, methods: str):
+        self.model = model
+        self.avgs_dict = {}
+        for method in methods.split(','):
+            args = method.split('_')
+            # method_name = args[0][:-1]  if args[0].endswith('_') else args[0]
+            # freq = int(args[1]) if len(args) > 1 else 1
+            self.avgs_dict[method] = Averager(model, args)
+
+    def step(self):
+        for avg in self.avgs_dict.values():
+            avg.step()
+
+
+class Averager(object):
+    def __init__(self, model, args):
+        self.model = model
+        self.method = args[0]
+        self.update_counter = 1
+        self.step_counter = 1
+        self.freq = 1 if (len(args) <= 2 ) else int(args[2])        
+        if self.method == 'none':
+            self.av_model = model
+            return
+        else:
+            self.av_model = deepcopy(unwrap_model(model))
+
+        if self.method == 'poly':
+            self.eta = 0.0 if len(args) <= 1 else float(args[1])
+        elif self.method == 'ema':
+            self.gamma = 0.99 if len(args) <= 1 else float(args[1])
+        
+        elif self.method == 'cosine':
+            pass
+        else:
+            print(f'Unknown averaging method {self.method}')
+
+    def step(self):
+        if self.update_counter != self.freq:
+            pass
+        else:
+            self.update()
+        self.update_counter += 1
+        if self.update_counter > self.freq:
+            self.update_counter = 1
+        return
+
+    def update(self):
+        method = self.method
+        if method == 'none':
+            return
+        t = self.step_counter
+        # model_sd is the current model state dict
+        # av_sd is the averaged model state dict
+        model_sd = self.model.state_dict()
+        av_sd = self.av_model.state_dict()
+        if self.method == 'cosine' or self.method == 'degree':
+            pass
+        first_k_av_sd = list(av_sd.keys())[0]
+        for k in model_sd.keys():
+            av_sd_k = k
+            if k.startswith("module") and not first_k_av_sd.startswith("module"):
+                av_sd_k = k[len("module."):]
+            if isinstance(av_sd[av_sd_k], (torch.LongTensor, torch.cuda.LongTensor)):  
+                # these are buffers that store how many batches batch norm has seen so far
+                av_sd[av_sd_k].copy_(model_sd[k])
+                continue
+            if method == 'poly':
+                # the update rule is: new_average = (1 - (eta + 1) / (eta + t)) * old_average + (eta + 1) / (eta + t) * current_model 
+                # which is eq(10) in https://arxiv.org/pdf/1212.1824.pdf
+                av_sd[av_sd_k].mul_(1 - ((self.eta + 1) / (self.eta + t))).add_(
+                    model_sd[k], alpha=(self.eta + 1) / (self.eta + t)
+                )
+            if method == 'ema':
+                # the update rule is: new_average = (1 - gamma) * old_average + gamma * current_model
+                av_sd[av_sd_k].mul_(self.gamma).add_(
+                    model_sd[k], alpha=1 - self.gamma
+                )
+        self.step_counter += 1
+        
+
+    def reset(self):
+        self.step_counter = 2
+
+    @property
+    def averaged_model(self):
+        return self.av_model
+
+    def get_state_dict_avg(self):
+        state_dict = {'update_counter': self.update_counter, 
+        'step_counter': self.step_counter, 
+        'freq': self.freq, 
+        'av_model_sd': unwrap_model(self.av_model).state_dict(),
+        'method': self.method,
+        'eta': self.eta if hasattr(self, 'eta') else None,
+        'gamma': self.gamma if hasattr(self, 'gamma') else None,
+        'suffix_steps': self.suffix_steps if hasattr(self, 'suffix_steps') else None,
+        'power': self.power if hasattr(self, 'power') else None,
+        'start': self.start if hasattr(self, 'start') else None,
+        } 
+        return state_dict
+    
+    def load_state_dict_avg(self, state_dict):
+        self.update_counter = state_dict['update_counter']
+        self.step_counter = state_dict['step_counter']
+        self.freq = state_dict['freq']
+        self.method = state_dict['method']
+        self.av_model.load_state_dict(state_dict['av_model_sd'])
+        if hasattr(self, 'eta'):
+            self.eta = state_dict['eta']
+        if hasattr(self, 'gamma'):
+            self.gamma = state_dict['gamma']
+        if hasattr(self, 'suffix_steps'):
+            self.suffix_steps = state_dict['suffix_steps']
+        if hasattr(self, 'power'):
+            self.power = state_dict['power']
+        if hasattr(self, 'start'):
+            self.start = state_dict['start']

--- a/open_lm/utils/averaging_utils.py
+++ b/open_lm/utils/averaging_utils.py
@@ -3,17 +3,17 @@ import torch
 import logging
 from copy import deepcopy
 
-def unwrap_model(model):
-    return model.module if hasattr(model, 'module') else model
 
+def unwrap_model(model):
+    return model.module if hasattr(model, "module") else model
 
 
 class ModelAverager(object):
     def __init__(self, model, methods: str):
         self.model = model
         self.avgs_dict = {}
-        for method in methods.split(','):
-            args = method.split('_')
+        for method in methods.split(","):
+            args = method.split("_")
             # method_name = args[0][:-1]  if args[0].endswith('_') else args[0]
             # freq = int(args[1]) if len(args) > 1 else 1
             self.avgs_dict[method] = Averager(model, args)
@@ -29,22 +29,22 @@ class Averager(object):
         self.method = args[0]
         self.update_counter = 1
         self.step_counter = 1
-        self.freq = 1 if (len(args) <= 2 ) else int(args[2])        
-        if self.method == 'none':
+        self.freq = 1 if (len(args) <= 2) else int(args[2])
+        if self.method == "none":
             self.av_model = model
             return
         else:
             self.av_model = deepcopy(unwrap_model(model))
 
-        if self.method == 'poly':
+        if self.method == "poly":
             self.eta = 0.0 if len(args) <= 1 else float(args[1])
-        elif self.method == 'ema':
+        elif self.method == "ema":
             self.gamma = 0.99 if len(args) <= 1 else float(args[1])
-        
-        elif self.method == 'cosine':
+
+        elif self.method == "cosine":
             pass
         else:
-            print(f'Unknown averaging method {self.method}')
+            print(f"Unknown averaging method {self.method}")
 
     def step(self):
         if self.update_counter != self.freq:
@@ -58,37 +58,34 @@ class Averager(object):
 
     def update(self):
         method = self.method
-        if method == 'none':
+        if method == "none":
             return
         t = self.step_counter
         # model_sd is the current model state dict
         # av_sd is the averaged model state dict
         model_sd = self.model.state_dict()
         av_sd = self.av_model.state_dict()
-        if self.method == 'cosine' or self.method == 'degree':
+        if self.method == "cosine" or self.method == "degree":
             pass
         first_k_av_sd = list(av_sd.keys())[0]
         for k in model_sd.keys():
             av_sd_k = k
             if k.startswith("module") and not first_k_av_sd.startswith("module"):
-                av_sd_k = k[len("module."):]
-            if isinstance(av_sd[av_sd_k], (torch.LongTensor, torch.cuda.LongTensor)):  
+                av_sd_k = k[len("module.") :]
+            if isinstance(av_sd[av_sd_k], (torch.LongTensor, torch.cuda.LongTensor)):
                 # these are buffers that store how many batches batch norm has seen so far
                 av_sd[av_sd_k].copy_(model_sd[k])
                 continue
-            if method == 'poly':
-                # the update rule is: new_average = (1 - (eta + 1) / (eta + t)) * old_average + (eta + 1) / (eta + t) * current_model 
+            if method == "poly":
+                # the update rule is: new_average = (1 - (eta + 1) / (eta + t)) * old_average + (eta + 1) / (eta + t) * current_model
                 # which is eq(10) in https://arxiv.org/pdf/1212.1824.pdf
                 av_sd[av_sd_k].mul_(1 - ((self.eta + 1) / (self.eta + t))).add_(
                     model_sd[k], alpha=(self.eta + 1) / (self.eta + t)
                 )
-            if method == 'ema':
+            if method == "ema":
                 # the update rule is: new_average = (1 - gamma) * old_average + gamma * current_model
-                av_sd[av_sd_k].mul_(self.gamma).add_(
-                    model_sd[k], alpha=1 - self.gamma
-                )
+                av_sd[av_sd_k].mul_(self.gamma).add_(model_sd[k], alpha=1 - self.gamma)
         self.step_counter += 1
-        
 
     def reset(self):
         self.step_counter = 2
@@ -98,32 +95,33 @@ class Averager(object):
         return self.av_model
 
     def get_state_dict_avg(self):
-        state_dict = {'update_counter': self.update_counter, 
-        'step_counter': self.step_counter, 
-        'freq': self.freq, 
-        'av_model_sd': unwrap_model(self.av_model).state_dict(),
-        'method': self.method,
-        'eta': self.eta if hasattr(self, 'eta') else None,
-        'gamma': self.gamma if hasattr(self, 'gamma') else None,
-        'suffix_steps': self.suffix_steps if hasattr(self, 'suffix_steps') else None,
-        'power': self.power if hasattr(self, 'power') else None,
-        'start': self.start if hasattr(self, 'start') else None,
-        } 
+        state_dict = {
+            "update_counter": self.update_counter,
+            "step_counter": self.step_counter,
+            "freq": self.freq,
+            "av_model_sd": unwrap_model(self.av_model).state_dict(),
+            "method": self.method,
+            "eta": self.eta if hasattr(self, "eta") else None,
+            "gamma": self.gamma if hasattr(self, "gamma") else None,
+            "suffix_steps": self.suffix_steps if hasattr(self, "suffix_steps") else None,
+            "power": self.power if hasattr(self, "power") else None,
+            "start": self.start if hasattr(self, "start") else None,
+        }
         return state_dict
-    
+
     def load_state_dict_avg(self, state_dict):
-        self.update_counter = state_dict['update_counter']
-        self.step_counter = state_dict['step_counter']
-        self.freq = state_dict['freq']
-        self.method = state_dict['method']
-        self.av_model.load_state_dict(state_dict['av_model_sd'])
-        if hasattr(self, 'eta'):
-            self.eta = state_dict['eta']
-        if hasattr(self, 'gamma'):
-            self.gamma = state_dict['gamma']
-        if hasattr(self, 'suffix_steps'):
-            self.suffix_steps = state_dict['suffix_steps']
-        if hasattr(self, 'power'):
-            self.power = state_dict['power']
-        if hasattr(self, 'start'):
-            self.start = state_dict['start']
+        self.update_counter = state_dict["update_counter"]
+        self.step_counter = state_dict["step_counter"]
+        self.freq = state_dict["freq"]
+        self.method = state_dict["method"]
+        self.av_model.load_state_dict(state_dict["av_model_sd"])
+        if hasattr(self, "eta"):
+            self.eta = state_dict["eta"]
+        if hasattr(self, "gamma"):
+            self.gamma = state_dict["gamma"]
+        if hasattr(self, "suffix_steps"):
+            self.suffix_steps = state_dict["suffix_steps"]
+        if hasattr(self, "power"):
+            self.power = state_dict["power"]
+        if hasattr(self, "start"):
+            self.start = state_dict["start"]


### PR DESCRIPTION
Supports EMA and polynomial averaging. Includes option for more than one averaged model and taking intermittent averaging.
For example, running EMA with parameter 0.999 and period 100 and polynomial averaging with parameter 8 and period 10, use
`--averagers="ema_0.999_100,poly_8_10"`
Logging of training loss of the averaged models can be done by choosing `--log-avg-model-training-loss` to be bigger than zero.