### PR TITLE
adding cosine rewarmed scheduler

### DIFF
--- a/open_lm/main.py
+++ b/open_lm/main.py
@@ -51,7 +51,7 @@ from open_lm.data import get_data, get_wds_dataset
 from open_lm.distributed import is_master, init_distributed_device, broadcast_object
 from open_lm.logger import setup_logging
 from open_lm.params import parse_args
-from open_lm.scheduler import cosine_lr, const_lr
+from open_lm.scheduler import cosine_lr, const_lr, cosine_rewarmed_lr
 from open_lm.train import train_one_epoch
 from open_lm.evaluate import evaluate_loop
 from open_lm.file_utils import (
@@ -686,8 +686,21 @@ def main(args):
                 # args.lr_cooldown_end,
                 # args.force_min_lr,
             )
+        elif args.lr_scheduler == "cosine-rewarmed":
+            scheduler = cosine_rewarmed_lr(
+                optimizer,
+                args.lr,
+                args.warmup,
+                total_steps,
+                args.lr_cooldown_end,
+                args.force_min_lr,
+                args.cosine_rewarmed_target_steps,
+                args.cosine_rewarmed_original_warmup,
+            )
         else:
-            raise ValueError(f"Unknown scheduler, {args.lr_scheduler}. Available options are: cosine, const.")
+            raise ValueError(
+                f"Unknown scheduler, {args.lr_scheduler}. Available options are: cosine, const, cosine-rewarned."
+            )
 
     # determine if this worker should save logs and checkpoints. only do so if it is rank == 0
     args.save_logs = args.logs and args.logs.lower() != "none" and is_master(args)

--- a/open_lm/params.py
+++ b/open_lm/params.py
@@ -237,9 +237,9 @@ def check_args(args):
             if args.remote_sync_protocol != "s3":
                 raise ValueError("Sync protocol not supported when using resume latest.")
 
-    if args.lr_scheduler not in {"cosine", "const", "const-cooldown"}:
+    if args.lr_scheduler not in {"cosine", "const", "cosine-rewarmed"}:
         raise ValueError(
-            f"Unknown scheduler, {args.lr_scheduler}. Available options are: cosine, const, const-cooldown."
+            f"Unknown scheduler, {args.lr_scheduler}. Available options are: cosine, const, cosine-rewarmed."
         )
 
     if args.experimental_meta_device:
@@ -391,7 +391,19 @@ def parse_args(args):
         "--lr-scheduler",
         type=str,
         default="cosine",
-        help="LR scheduler. One of: 'cosine', 'const' (constant), 'const-cooldown' (constant w/ cooldown). Default: cosine",
+        help="LR scheduler. One of: 'cosine', 'const' (constant), 'const-cooldown' (constant w/ cooldown), 'cosine-rewarmed'. Default: cosine",
+    )
+    parser.add_argument(
+        "--cosine-rewarmed-target-steps",
+        type=int,
+        default=None,
+        help="for cosine rewarmed, the target steps for the cosine schedule. Default: cosine",
+    )
+    parser.add_argument(
+        "--cosine-rewarmed-original-warmup",
+        type=int,
+        default=1000,
+        help="for cosine rewarmed, the original warmup steps. Default: 1000",
     )
     parser.add_argument(
         "--lr-cooldown-end",


### PR DESCRIPTION

![image](https://github.com/mlfoundations/open_lm/assets/57691643/3469cb69-18ea-4110-8463-0965c170bd4b)

Adding cosine rewarmed scheduler. Rewarming to where cosine would have been if running for the total number of steps - of both original and rewarmed runs.

There are two arguments that are used:

`--cosine-rewarmed-target-steps` - set the total number of _steps_.
`--cosine-rewarmed-original-warmup` - number of warmup steps in the runs before rewarming. default: 1000.

Choose `base_lr` to be the base lr you would use in the run with total number of steps. The new base_lr is computed within the scheduler