### PR TITLE
Input embed

### DIFF
--- a/eval/eval_openlm_ckpt.py
+++ b/eval/eval_openlm_ckpt.py
@@ -7,7 +7,14 @@ import torch
 from composer.loggers import InMemoryLogger, LoggerDestination
 from composer.trainer import Trainer
 from composer.utils import dist, get_device, reproducibility
-from llmfoundry.utils.builders import build_icl_evaluators, build_logger
+
+try:
+    from llmfoundry.utils.builders import build_icl_evaluators, build_logger
+except ImportError:
+    import logging
+
+    logging.warning("llmfoundry not installed. Please install llmfoundry `pip install llm-foundry` to run this script.")
+
 from omegaconf import OmegaConf as om
 from transformers import GPTNeoXTokenizerFast, LlamaTokenizerFast
 

--- a/open_lm/model.py
+++ b/open_lm/model.py
@@ -396,7 +396,7 @@ class Transformer(nn.Module, PyTorchModelHubMixin):
             x = inputs_embeds
         else:
             raise ValueError("Either input_ids or inputs_embeds must be provided.")
-        
+
         x = self.post_embed_norm(x)
 
         if past_key_values is None:

--- a/open_lm/model.py
+++ b/open_lm/model.py
@@ -380,7 +380,7 @@ class Transformer(nn.Module, PyTorchModelHubMixin):
     def set_grad_checkpointing(self, enable=True):
         self.grad_checkpointing = enable
 
-    def forward(self, input, past_key_values=None, use_cache=False, attention_mask=None):
+    def forward(self, input_ids=None, inputs_embeds=None, past_key_values=None, use_cache=False, attention_mask=None):
         """
         Args:
             input
@@ -390,7 +390,13 @@ class Transformer(nn.Module, PyTorchModelHubMixin):
                 attended to. attention_mask[s, i] = False indicates that token i should not be attended to by any other
                 token for sequence s.
         """
-        x = self.tok_embeddings(input)
+        if input_ids is not None:
+            x = self.tok_embeddings(input_ids)
+        elif inputs_embeds is not None:
+            x = inputs_embeds
+        else:
+            raise ValueError("Either input_ids or inputs_embeds must be provided.")
+        
         x = self.post_embed_norm(x)
 
         if past_key_values is None:

--- a/open_lm/utils/llm_foundry_wrapper.py
+++ b/open_lm/utils/llm_foundry_wrapper.py
@@ -51,4 +51,4 @@ class SimpleComposerOpenLMCausalLM(HuggingFaceModel):
         )
 
     def generate(self, input_ids=None, inputs_embeds=None, **kwargs):
-        return super().generate(input_ids, inputs_embeds, **kwargs)
+        return super().generate(input_ids=input_ids, inputs_embeds=inputs_embeds, **kwargs)

--- a/open_lm/utils/llm_foundry_wrapper.py
+++ b/open_lm/utils/llm_foundry_wrapper.py
@@ -50,5 +50,5 @@ class SimpleComposerOpenLMCausalLM(HuggingFaceModel):
             shift_labels=True,
         )
 
-    def generate(self, input_ids, **kwargs):
+    def generate(self, input_ids=None, **kwargs):
         return super().generate(input_ids, **kwargs)

--- a/open_lm/utils/llm_foundry_wrapper.py
+++ b/open_lm/utils/llm_foundry_wrapper.py
@@ -50,5 +50,5 @@ class SimpleComposerOpenLMCausalLM(HuggingFaceModel):
             shift_labels=True,
         )
 
-    def generate(self, input_ids=None, **kwargs):
-        return super().generate(input_ids, **kwargs)
+    def generate(self, input_ids=None, inputs_embeds=None, **kwargs):
+        return super().generate(input_ids, inputs_embeds, **kwargs)

--- a/open_lm/utils/llm_foundry_wrapper.py
+++ b/open_lm/utils/llm_foundry_wrapper.py
@@ -51,4 +51,4 @@ class SimpleComposerOpenLMCausalLM(HuggingFaceModel):
         )
 
     def generate(self, input_ids=None, inputs_embeds=None, **kwargs):
-        return super().generate(input_ids=input_ids, inputs_embeds=inputs_embeds, **kwargs)
+        return super().generate(input_ids=input_ids, **kwargs)

--- a/open_lm/utils/transformers/hf_model.py
+++ b/open_lm/utils/transformers/hf_model.py
@@ -90,17 +90,17 @@ class OpenLMforCausalLM(OpenLMModel):
         assert position_ids is None, "Position IDs are not supported"
         # decoder outputs consists of (dec_features, layer_state, dec_hidden, dec_attn)
         logits, _, past_key_values = self.model(
-            input_ids=input_ids, inputs_embeds=inputs_embeds, past_key_values=past_key_values, use_cache=use_cache, attention_mask=attention_mask
+            input_ids=input_ids,
+            inputs_embeds=inputs_embeds,
+            past_key_values=past_key_values,
+            use_cache=use_cache,
+            attention_mask=attention_mask,
         )
         loss = None
         if labels is not None:
             loss = nn.CrossEntropyLoss()(logits.view(-1, logits.size(-1)), labels.view(-1))
 
-        output = CausalLMOutputWithPast(
-            logits=logits,
-            past_key_values=past_key_values,
-            loss=loss
-        )
+        output = CausalLMOutputWithPast(logits=logits, past_key_values=past_key_values, loss=loss)
         return output
 
     def prepare_inputs_for_generation(

--- a/open_lm/utils/transformers/hf_model.py
+++ b/open_lm/utils/transformers/hf_model.py
@@ -33,8 +33,8 @@ class OpenLMModel(PreTrainedModel):
     def gradient_checkpointing(self, value):
         self.model.grad_checkpointing = value
 
-    def forward(self, tokens):
-        return self.model(tokens)
+    def forward(self, input_ids=None, inputs_embeds=None, **kwargs):
+        return self.model(input_ids=input_ids, inputs_embeds=inputs_embeds, **kwargs)
 
 
 class OpenLMforCausalLM(OpenLMModel):

--- a/open_lm/utils/transformers/hf_model.py
+++ b/open_lm/utils/transformers/hf_model.py
@@ -107,7 +107,12 @@ class OpenLMforCausalLM(OpenLMModel):
         )
         loss = None
         if labels is not None:
-            loss = nn.CrossEntropyLoss()(logits.view(-1, logits.size(-1)), labels.view(-1))
+            shift_logits = logits[..., :-1, :].contiguous()
+            shift_labels = labels[..., 1:].contiguous()
+            loss_fct = nn.CrossEntropyLoss()
+            shift_logits = shift_logits.view(-1, shift_logits.size(-1))
+            shift_labels = shift_labels.view(-1).to(shift_logits.device)
+            loss = loss_fct(shift_logits, shift_labels)
 
         output = CausalLMOutputWithPast(logits=logits, past_key_values=past_key_values, loss=loss)
         return output

--- a/open_lm/utils/transformers/hf_model.py
+++ b/open_lm/utils/transformers/hf_model.py
@@ -1,4 +1,5 @@
 from argparse import Namespace
+from torch.utils.checkpoint import checkpoint
 from transformers import PreTrainedModel
 from transformers.modeling_outputs import CausalLMOutputWithPast
 from open_lm.utils.transformers.hf_config import OpenLMConfig
@@ -19,10 +20,18 @@ class OpenLMModel(PreTrainedModel):
         else:
             params = create_params(Namespace(**config.params_args_dict))
         config.set_params(params)
-
         super().__init__(config)
 
+        self.supports_gradient_checkpointing = True
         self.model = Transformer(params)
+
+    @property
+    def gradient_checkpointing(self):
+        return self.model.grad_checkpointing
+
+    @gradient_checkpointing.setter
+    def gradient_checkpointing(self, value):
+        self.model.grad_checkpointing = value
 
     def forward(self, tokens):
         return self.model(tokens)

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,4 +24,4 @@ transformers
 s3fs
 wikipedia
 ipython
-# llm-foundry>=0.4.0
+mosaicml

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,4 +24,4 @@ transformers
 s3fs
 wikipedia
 ipython
-llm-foundry>=0.4.0
+# llm-foundry>=0.4.0

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -3,3 +3,4 @@ pytest-cov==3.0.0
 pytest-xdist==2.5.0
 pytest==7.0.1
 tensorboard==2.14.1
+llm-foundry>=0.4.0

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -218,7 +218,7 @@ def run_model(open_lm, tokenizer, args, wiki_page=None, start_index=None):
         generate_args["top_p"] = args.top_p
 
     output = composer_model.generate(
-        input["input_ids"],
+        input_ids=input["input_ids"],
         **generate_args,
     )
     output = tokenizer.decode(output[0].cpu().numpy())


### PR DESCRIPTION
This allows calling the model with inputs_embeds arguments instead of input_ids if needed.

It also removes llm-foundry from the requirements. It is already explained in the README that llm-foundry is a separate additional installation to make. 
llm-foundry is extremely strict in its requirements and makes a lot of packages incompatible with OpenLM so I don't think it should be required. Moreover it's only used for eval so it is not actually required by the main model.