### PR TITLE
Parameter input rotary-freq

### DIFF
--- a/open_lm/model.py
+++ b/open_lm/model.py
@@ -98,15 +98,16 @@ class Params:
     moe_top_k: int = 2
     moe_freq: int = 0
     positional_embedding_type: str = "rotary"
+    rotary_freq: float = 10000
     ffn_type: str = "swiglu"
 
 
 def get_pos_embed(args: Params):
     head_dim = args.dim // args.n_heads
     if args.positional_embedding_type == "rotary":
-        return RotaryWithCast(head_dim, args.seq_len)
+        return RotaryWithCast(head_dim, args.seq_len, args.rotary_freq)
     elif args.positional_embedding_type == "llama_rotary":
-        return LLaMARotaryWithCast(head_dim, args.n_heads, args.seq_len)
+        return LLaMARotaryWithCast(head_dim, args.n_heads, args.seq_len, args.rotary_freq)
     elif args.positional_embedding_type == "head_rotary":
         return HeadRotaryWithCast(head_dim, args.seq_len)
     elif args.positional_embedding_type == "none":
@@ -462,6 +463,7 @@ def create_params(args):
             ),
             apply_qk_norm=cfg.get("qk_norm", args.qk_norm),
             positional_embedding_type=cfg.get("positional_embedding_type", args.positional_embedding_type),
+            rotary_freq=cfg.get("rotary_freq", args.rotary_freq),
             ffn_type=cfg.get("ffn_type", args.ffn_type),
             moe_num_experts=cfg.get("moe_num_experts", args.moe_num_experts),
             moe_loss_weight=cfg.get("moe_loss_weight", args.moe_loss_weight),

--- a/open_lm/params.py
+++ b/open_lm/params.py
@@ -59,6 +59,12 @@ def add_model_args(parser):
         help="Type of positional embedding to use. This might be overridden by the model config.",
     )
     parser.add_argument(
+        "--rotary-freq",
+        type=float,
+        default=10000,
+        help="Frequency for rotary positional embeddings. This might be overridden by the model config.",
+    )
+    parser.add_argument(
         "--moe-freq",
         type=int,
         default=0,

--- a/open_lm/positional_embedding/llama_rotary.py
+++ b/open_lm/positional_embedding/llama_rotary.py
@@ -112,7 +112,7 @@ class LLaMARotaryEmbedding(torch.nn.Module):
         (it does not create the embedding dimension) and will likely be picked up (imported) on a ad-hoc basis
     """
 
-    def __init__(self, head_dim: int, num_heads: int, seq_len: int, *_, **__):
+    def __init__(self, head_dim: int, num_heads: int, seq_len: int, frequency: float = 10000, *_, **__):
         super().__init__()
         # Generate and save the inverse frequency buffer (non trainable)
         self.freqs_cis = precompute_freqs_cis(
@@ -120,6 +120,7 @@ class LLaMARotaryEmbedding(torch.nn.Module):
             # Adding this multiplier instead of using 4096 directly allows for dynamism of token lengths while training or fine-tuning.
             head_dim,
             seq_len * 2,
+            theta=frequency,
         )
 
     def reset_parameters(self):

--- a/open_lm/positional_embedding/rotary.py
+++ b/open_lm/positional_embedding/rotary.py
@@ -44,7 +44,7 @@ class RotaryEmbedding(torch.nn.Module):
         (it does not create the embedding dimension) and will likely be picked up (imported) on a ad-hoc basis
     """
 
-    def __init__(self, dim_model: int, seq_len: int, *_, **__):
+    def __init__(self, dim_model: int, seq_len: int, frequency: float = 10000, *_, **__):
         super().__init__()
         # Generate and save the inverse frequency buffer (non trainable)
         self.dim_model = dim_model
@@ -54,10 +54,11 @@ class RotaryEmbedding(torch.nn.Module):
         self._sin_cached = None
         self._seq_len_cached = 0
         self.seq_len = seq_len
+        self.frequency = frequency
         self.reset_parameters()
 
     def reset_parameters(self):
-        self.inv_freq = 1.0 / (10000 ** (torch.arange(0, self.dim_model, 2).float() / self.dim_model))
+        self.inv_freq = 1.0 / (self.frequency ** (torch.arange(0, self.dim_model, 2).float() / self.dim_model))
         self._update_cos_sin_tables(self.seq_len)
 
     def _update_cos_sin_tables(self, seq_len: int = None, device: torch.device = None, dtype: torch.dtype = None):


### PR DESCRIPTION
This allows to change the rotary positional embedding frequency parameter.
This is useful given the more recent approaches:
LLaMA 1&2 used 10000 which is the default value here.
LLaMA 3 uses 500000, Mistral uses 1000000
LLaMA long context extension works usually increase from 10000 to 100000.