### PR TITLE
Improve error handling for s3 read errors.

### DIFF
--- a/open_lm/main.py
+++ b/open_lm/main.py
@@ -835,7 +835,7 @@ def main(args):
 
         if num_ckpt_too_few_tokens > args.data_tolerate_num_ckpts:
             raise RuntimeError(
-                f"{num_ckpt_too_few_tokens} checkpoints happened where the number of tokens seen was less than {args.expected_tokens} of expected. This is likely due to transient errors e.g. reading from S3."
+                f"{num_ckpt_too_few_tokens} checkpoints happened where the number of tokens seen was less than {1 - args.data_tolerate_error_p} of expected. This is likely due to transient errors e.g. reading from S3."
             )
 
         epoch = epoch + 1

--- a/open_lm/main.py
+++ b/open_lm/main.py
@@ -871,6 +871,7 @@ def main(args):
                 "epoch": epoch,
                 "tokens": (global_step + 1) * args.global_batch_size * args.seq_len,
                 "checkpoints_too_few_tokens": num_ckpt_too_few_tokens,
+                "percentage_of_data_seen": steps_done_epoch / expected_steps,
             }
 
             if args.dataset_manifest is not None:

--- a/open_lm/main.py
+++ b/open_lm/main.py
@@ -59,6 +59,7 @@ from open_lm.file_utils import (
     check_exists,
     start_sync_process,
     remote_sync_with_expon_backoff,
+    get_metadata_file,
     get_string_for_epoch,
     log_num_checkpoints,
     terminate_sync_process,
@@ -875,6 +876,9 @@ def main(args):
             if args.dataset_manifest is not None:
                 for i in range(len(next_shard_per_source)):
                     end_of_epoch_log[f"next_shard_{i}"] = next_shard_per_source[i]
+                    end_of_epoch_log[f"dataset_pass_{i}"] = next_shard_per_source[i] // len(
+                        get_metadata_file(args.dataset_manifest[i])
+                    )
 
             for name, val in end_of_epoch_log.items():
                 name = "train/" + name

--- a/open_lm/main.py
+++ b/open_lm/main.py
@@ -203,6 +203,7 @@ def save_checkpoint(
     next_shard_per_source=None,
     samples_seen=None,
     shard_shuffle_seed=None,
+    train_data_string=None,
     averagers=None,
 ):
     cpu_state, optim_state = None, None
@@ -246,6 +247,20 @@ def save_checkpoint(
             "is_final_checkpoint": is_final_checkpoint,
             "evaluation_metrics": evaluation_metrics,
         }
+        if next_shard_per_source is not None:
+            checkpoint_dict_stats["next_shard_per_source"] = next_shard_per_source
+
+        if samples_seen is not None:
+            checkpoint_dict_stats["samples_seen"] = samples_seen
+
+        if step is not None:
+            checkpoint_dict_stats["step"] = step
+
+        if shard_shuffle_seed is not None:
+            checkpoint_dict_stats["shard_shuffle_seed"] = shard_shuffle_seed
+        
+        if train_data_string is not None:
+            checkpoint_dict_stats["train_data_string"] = train_data_string
 
         prefixes = {
             "epoch_": checkpoint_dict_model,
@@ -881,6 +896,7 @@ def main(args):
             next_shard_per_source=next_shard_per_source if args.dataset_manifest is not None else None,
             samples_seen=samples_seen if args.dataset_manifest is not None else None,
             shard_shuffle_seed=args.shard_shuffle_seed,
+            train_data_string=train_data_string_per_source if args.dataset_manifest is not None else None,
             averagers=averagers,
         )
 

--- a/open_lm/main.py
+++ b/open_lm/main.py
@@ -825,10 +825,10 @@ def main(args):
             break
 
         expected_steps = sum(num_samples_per_source) // args.global_batch_size
-        if steps_done_epoch < args.expected_tokens * expected_steps:
+        if steps_done_epoch < (1 - args.data_tolerate_error_p) * expected_steps:
             num_ckpt_too_few_tokens += 1
 
-        if num_ckpt_too_few_tokens > args.max_ckpt_too_few_tokens:
+        if num_ckpt_too_few_tokens > args.data_tolerate_num_ckpts:
             raise RuntimeError(
                 f"{num_ckpt_too_few_tokens} checkpoints happened where the number of tokens seen was less than {args.expected_tokens} of expected. This is likely due to transient errors e.g. reading from S3."
             )

--- a/open_lm/main.py
+++ b/open_lm/main.py
@@ -824,12 +824,7 @@ def main(args):
             logging.info("Training exiting due to NaN value")
             break
 
-        if args.dataset_manifest is not None:
-            expected_samples = sum(num_samples_per_source)
-        else:
-            expected_samples = args.train_num_samples
-
-        expected_steps = expected_samples // args.global_batch_size
+        expected_steps = data["train"].dataloader.total_batches
         if steps_done_epoch < (1 - args.data_tolerate_error_p) * expected_steps:
             num_ckpt_too_few_tokens += 1
 

--- a/open_lm/main.py
+++ b/open_lm/main.py
@@ -873,7 +873,8 @@ def main(args):
             }
 
             if args.dataset_manifest is not None:
-                end_of_epoch_log["next_shard"] = next_shard_per_source[0]
+                for i in range(len(next_shard_per_source)):
+                    end_of_epoch_log[f"next_shard_{i}"] = next_shard_per_source[i]
 
             for name, val in end_of_epoch_log.items():
                 name = "train/" + name

--- a/open_lm/main.py
+++ b/open_lm/main.py
@@ -825,7 +825,7 @@ def main(args):
             break
 
         expected_steps = data["train"].dataloader.total_batches
-        if steps_done_epoch < (1 - args.data_tolerate_error_p) * expected_steps:
+        if steps_done_epoch < (1 - args.data_tolerate_error_p) * expected_steps and not done_training:
             num_ckpt_too_few_tokens += 1
 
         if num_ckpt_too_few_tokens > args.data_tolerate_num_ckpts:

--- a/open_lm/main.py
+++ b/open_lm/main.py
@@ -824,7 +824,12 @@ def main(args):
             logging.info("Training exiting due to NaN value")
             break
 
-        expected_steps = sum(num_samples_per_source) // args.global_batch_size
+        if args.dataset_manifest is not None:
+            expected_samples = sum(num_samples_per_source)
+        else:
+            expected_samples = args.train_num_samples
+
+        expected_steps = expected_samples // args.global_batch_size
         if steps_done_epoch < (1 - args.data_tolerate_error_p) * expected_steps:
             num_ckpt_too_few_tokens += 1
 

--- a/open_lm/main.py
+++ b/open_lm/main.py
@@ -258,7 +258,7 @@ def save_checkpoint(
 
         if shard_shuffle_seed is not None:
             checkpoint_dict_stats["shard_shuffle_seed"] = shard_shuffle_seed
-        
+
         if train_data_string is not None:
             checkpoint_dict_stats["train_data_string"] = train_data_string
 

--- a/open_lm/main.py
+++ b/open_lm/main.py
@@ -824,7 +824,7 @@ def main(args):
             logging.info("Training exiting due to NaN value")
             break
 
-        expected_steps = data["train"].dataloader.total_batches
+        expected_steps = data["train"].dataloader.num_batches
         if steps_done_epoch < (1 - args.data_tolerate_error_p) * expected_steps and not done_training:
             num_ckpt_too_few_tokens += 1
 

--- a/open_lm/params.py
+++ b/open_lm/params.py
@@ -775,6 +775,19 @@ def parse_args(args):
         default=0,
         help="Whether to log the average model training loss. if not 0, it will log the average loss over the specified number of steps.",
     )
+    parser.add_argument(
+        "--expected-tokens",
+        type=float,
+        default=0.91,  # Roughly the number required to not repeat more than 10% of data.
+        help="This is the percentage of expected tokens below which the checkpoint is considered failed because of not having seen enough data.",
+    )
+    parser.add_argument(
+        "--max-ckpt-too-few-tokens",
+        type=int,
+        default=0,
+        help="This is the maximum number of failed checkpoints (due to not having seen enough tokens) that are allowed",
+    )
+
     add_model_args(parser)
 
     config = maybe_load_config(parser, args)

--- a/open_lm/params.py
+++ b/open_lm/params.py
@@ -776,13 +776,13 @@ def parse_args(args):
         help="Whether to log the average model training loss. if not 0, it will log the average loss over the specified number of steps.",
     )
     parser.add_argument(
-        "--expected-tokens",
+        "--data-tolerate-error-p",
         type=float,
-        default=0.91,  # Roughly the number required to not repeat more than 10% of data.
-        help="This is the percentage of expected tokens below which the checkpoint is considered failed because of not having seen enough data.",
+        default=0.09,  # Roughly the number required to not repeat more than 10% of data.
+        help="This is the percentage of expected tokens above which the checkpoint is considered failed because of not having seen enough data.",
     )
     parser.add_argument(
-        "--max-ckpt-too-few-tokens",
+        "--data-tolerate-num-ckpts",
         type=int,
         default=0,
         help="This is the maximum number of failed checkpoints (due to not having seen enough tokens) that are allowed",

--- a/tests/test_training_simple.py
+++ b/tests/test_training_simple.py
@@ -86,6 +86,8 @@ def test_training_deterministic():
         "json",
         "--model-norm",
         "gain_only_layer_norm",
+        "--data-tolerate-error-p",
+        "1.0",
     ]
     args = [str(x) for x in args]
     args2 = copy.deepcopy(args)

--- a/tests/test_training_simple.py
+++ b/tests/test_training_simple.py
@@ -145,6 +145,8 @@ def test_good_resume_shard_shuffle():
         "json",
         "--model-norm",
         "gain_only_layer_norm",
+        "--data-tolerate-error-p",
+        "1.0",
     ]
     args = [str(x) for x in args]
 

--- a/tests/test_training_simple.py
+++ b/tests/test_training_simple.py
@@ -86,8 +86,6 @@ def test_training_deterministic():
         "json",
         "--model-norm",
         "gain_only_layer_norm",
-        "--data-tolerate-error-p",
-        "1.0",
     ]
     args = [str(x) for x in args]
     args2 = copy.deepcopy(args)
@@ -145,8 +143,6 @@ def test_good_resume_shard_shuffle():
         "json",
         "--model-norm",
         "gain_only_layer_norm",
-        "--data-tolerate-error-p",
-        "1.0",
     ]
     args = [str(x) for x in args]
 


### PR DESCRIPTION
This PR adds two flags:
- `--data-tolerate-error-p`: The percentage of tokens that should be seen by a checkpoint before we think it's a failure.
- `--data-tolerate-num-ckpts`: The maximum number of such failed checkpoints we allow.