### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ pandas==2.1.4
 fsspec
 tqdm
 jsonlines
-boto3==1.26.90
+boto3
 Pillow
 zstandard
 pysimdjson


### PR DESCRIPTION
I'm getting the following error when running `python sagemaker_train/launch_sagemaker_train.py --build-type full --user sedrick.keh --cfg-path (path-to-yaml-here)`:

ImportError: cannot import name 'is_s3express_bucket' from 'botocore.utils' (/opt/conda/lib/python3.10/site-packages/botocore/utils.py)

This is fixed by using an updated boto3 version. Is there a particular reason for using boto3==1.26.90?