### PR TITLE
Relax boto requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ pandas==2.1.4
 fsspec
 tqdm
 jsonlines
-boto3==1.26.90
+boto3>=1.26.90
 Pillow
 zstandard
 pysimdjson


### PR DESCRIPTION
not sure why we tied it to this old version, causes some requirements issues with other packages that rely on openlm