### PR TITLE
Faster eval

### DIFF
--- a/eval/eval_openlm_ckpt.py
+++ b/eval/eval_openlm_ckpt.py
@@ -123,6 +123,7 @@ def main():
 
     state_dict = checkpoint["state_dict"]
     state_dict = {x.replace("module.", ""): y for x, y in state_dict.items()}
+    state_dict = {x.replace("_orig_mod.", ""): y for x, y in state_dict.items()}
     open_lm.model.load_state_dict(state_dict)
     open_lm.model.eval()
 

--- a/eval/eval_openlm_ckpt.py
+++ b/eval/eval_openlm_ckpt.py
@@ -46,8 +46,9 @@ def evaluate(model, tokenizer, cfg):
 
     composer_model = SimpleComposerOpenLMCausalLM(model, tokenizer)
 
+    cfg_icl_tasks = [dict(i) for i in cfg.icl_tasks]
     evaluators, logger_keys = build_icl_evaluators(
-        cfg.icl_tasks, tokenizer, cfg.max_seq_len, cfg.device_eval_batch_size
+        cfg_icl_tasks, tokenizer, cfg.max_seq_len, cfg.device_eval_batch_size
     )
 
     in_memory_logger = InMemoryLogger()  # track metrics in the in_memory_logger

--- a/open_lm/model_configs/open_lm_1b_swiglutorch.json
+++ b/open_lm/model_configs/open_lm_1b_swiglutorch.json
@@ -1,0 +1,14 @@
+{
+    "hidden_dim": 2048,
+    "n_layers": 24,
+    "n_heads": 16,
+    "seq_len": 2048,
+    "vocab_size": 50432,
+    "post_embed_norm": false,
+    "weight_tying": false,
+    "model_norm": "gain_only_lp_layer_norm",
+    "norm_type": "gain_only_lp_layer_norm",
+    "ffn_type": "swiglu_torch",
+    "qk_norm": true,
+    "positional_embedding_type": "rotary"
+}

--- a/open_lm/utils/llm_foundry_wrapper.py
+++ b/open_lm/utils/llm_foundry_wrapper.py
@@ -3,7 +3,7 @@
 
 """Implements a Hugging Causal LM wrapped inside a :class:`.ComposerModel`."""
 
-from typing import Mapping, Union, List
+from typing import Union
 from llmfoundry.eval.metrics.nlp import (
     InContextLearningLMAccuracy,
     InContextLearningLMExpectedCalibrationError,
@@ -16,8 +16,6 @@ from composer.metrics.nlp import (
     LanguagePerplexity,
 )
 from transformers import PreTrainedTokenizer, PreTrainedTokenizerFast
-from transformers import StoppingCriteria, StoppingCriteriaList
-import torch
 
 from composer.models.huggingface import HuggingFaceModel
 
@@ -40,13 +38,6 @@ EVAL_METRICS = [
     InContextLearningMCExpectedCalibrationError(),
 ]
 
-class CustomStopTokensCriteria(StoppingCriteria):
-    def __init__(self, stop_tokens: List[str]) -> None:
-        self.stop_tokens = stop_tokens
-
-    def __call__(self, generated_tokens: torch.Tensor, *args, **kwargs) -> bool:
-        return any(token in self.stop_tokens for token in generated_tokens.flatten())
-
 
 class SimpleComposerOpenLMCausalLM(HuggingFaceModel):
     def __init__(self, model, tokenizer):
@@ -59,9 +50,4 @@ class SimpleComposerOpenLMCausalLM(HuggingFaceModel):
         )
 
     def generate(self, input_ids=None, inputs_embeds=None, **kwargs):
-        stop_token = self.tokenizer.eos_token_id
-        stop_criteria = CustomStopTokensCriteria([stop_token])
-        stop_criteria_list = StoppingCriteriaList([stop_criteria])
-        if "stopping_criteria" in kwargs:
-            stop_criteria_list += kwargs.pop("stopping_criteria")
-        return super().generate(input_ids=input_ids, stopping_criteria=stop_criteria_list, **kwargs)
+        return super().generate(input_ids=input_ids, **kwargs)


### PR DESCRIPTION
We might not want to merge this because it is hacky and there might be a usage that I don't foresee that could be impacted.

Problem:
Somewhere in llm-foundry or composer, the batches are appended with many stop tokens which makes the eval very slow.

Solution:
In `OpenLMforCausalLM` tests for 0s at the end of the input_ids batch and remove them. Add back fake logits at the end....

Consideration:
This hack could be implemented in `SimpleComposerOpenLMCausalLM` instead and would have less risk to have unforeseen impacts.
There shouldn't really be a need for this but I could not understand what was happening in Composer or llm-foundry or find where/why the inputs are appended with 0s.