### PR TITLE
fix: correct typos in validation data help text

### DIFF
--- a/open_lm/params.py
+++ b/open_lm/params.py
@@ -296,7 +296,7 @@ def parse_args(args):
         nargs="+",
         default=None,
         help=(
-            "Path to file(s) with validation data. Note: each space seperated entry will be processed seperately and writen as seperate entries "
+            "Path to file(s) with validation data. Note: each space separated entry will be processed separately and written as separate entries "
             "in a results.jsonl file."
         ),
     )


### PR DESCRIPTION
Fix typos in the help text for the --val-data argument:
- 'seperated' → 'separated'
- 'seperately' → 'separately'
- 'writen' → 'written'
- 'seperate' → 'separate'